### PR TITLE
fix wrong error state with tuf gen-key

### DIFF
--- a/cmd/tuf/gen_key.go
+++ b/cmd/tuf/gen_key.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/flynn/go-docopt"
 	"github.com/theupdateframework/go-tuf"
@@ -27,7 +28,8 @@ func cmdGenKey(args *docopt.Args, repo *tuf.Repo) error {
 	var keyids []string
 	var err error
 	if arg := args.String["--expires"]; arg != "" {
-		expires, err := parseExpires(arg)
+		var expires time.Time
+		expires, err = parseExpires(arg)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Hi @erickt and @trishankatdatadog,

This is my first 'real' PR. While playing around with tuf locally to get warm with it, I found this small
issue in the `tuf` command line tool.

You can reproduce this issue via:

```
$ go get github.com/theupdateframework/go-tuf/cmd/tuf
$ mkdir tuf-demo
$ cd tuf-demo
$ tuf init
$ tuf gen-key --expires=30 INVALID
```

With the current master the command will return exit code 0 and will not display any error code.
With my PR applied we get the correct result and `tuf gen-key --expires=30 INVALID` returns an error.
More details can be found in the commit message