### PR TITLE
Implement the TUF 1.0 workflow

### DIFF
--- a/client/errors.go
+++ b/client/errors.go
@@ -87,6 +87,19 @@ func IsLatestSnapshot(err error) bool {
 	return ok
 }
 
+type ErrOldRoot struct {
+	Version int
+}
+
+func (e ErrOldRoot) Error() string {
+	return fmt.Sprintf("tuf: the latest snapshot references a root version %d that is newer than the local version", e.Version)
+}
+
+func IsOldRoot(err error) bool {
+	_, ok := err.(ErrOldRoot)
+	return ok
+}
+
 type ErrUnknownTarget struct {
 	Name string
 }

--- a/repo.go
+++ b/repo.go
@@ -848,7 +848,7 @@ func (r *Repo) verifySignature(name string, db *verify.DB) error {
 		return err
 	}
 	role := strings.TrimSuffix(name, ".json")
-	if err := db.Verify(s, role, 0); err != nil {
+	if err := db.VerifyWithMinVersion(s, role, 0); err != nil {
 		return ErrInsufficientSignatures{name, err}
 	}
 	return nil

--- a/verify/errors.go
+++ b/verify/errors.go
@@ -58,3 +58,12 @@ type ErrRoleThreshold struct {
 func (e ErrRoleThreshold) Error() string {
 	return "tuf: valid signatures did not meet threshold"
 }
+
+type BadVersion struct {
+	Expected int
+	Actual   int
+}
+
+func (e BadVersion) Error() string {
+	return fmt.Sprintf("expected version %d but version must be %d", e.Expected, e.Actual)
+}

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -242,7 +242,7 @@ func (VerifySuite) Test(c *C) {
 			c.Assert(err, IsNil)
 		}
 
-		err := db.Verify(t.s, t.role, minVer)
+		err := db.VerifyWithMinVersion(t.s, t.role, minVer)
 		if e, ok := t.err.(ErrExpired); ok {
 			assertErrExpired(c, err, e)
 		} else {


### PR DESCRIPTION
This migrates go-tuf over to using the TUF 1.0 workflow for updating repositories.