### PR TITLE
Add rsassa-pss-sha256 verifier

### DIFF
--- a/data/types.go
+++ b/data/types.go
@@ -11,11 +11,13 @@ import (
 )
 
 const (
-	KeyIDLength              = sha256.Size * 2
-	KeyTypeEd25519           = "ed25519"
-	KeyTypeECDSA_SHA2_P256   = "ecdsa-sha2-nistp256"
-	KeySchemeEd25519         = "ed25519"
-	KeySchemeECDSA_SHA2_P256 = "ecdsa-sha2-nistp256"
+	KeyIDLength                = sha256.Size * 2
+	KeyTypeRSASSA_PSS_SHA256   = "rsassa-pss-sha256"
+	KeyTypeEd25519             = "ed25519"
+	KeyTypeECDSA_SHA2_P256     = "ecdsa-sha2-nistp256"
+	KeySchemeRSASSA_PSS_SHA256 = "rsassa-pss-sha256"
+	KeySchemeEd25519           = "ed25519"
+	KeySchemeECDSA_SHA2_P256   = "ecdsa-sha2-nistp256"
 )
 
 var (


### PR DESCRIPTION
Based on RSAVerifier removed in theupdateframework/go-tuf#96 and ECDSA support added in theupdateframework/go-tuf#98

This improves compatibility with reference Python TUF and other TUF implementations. go-tuf already supports the other two verifiers (ECDSA, ED25519) mentioned in the TUF spec, so this completes the set.

Happy to make changes, add tests, etc as per PR feedback.