### PR TITLE
Ignore unknown keyids

### DIFF
--- a/data/types_test.go
+++ b/data/types_test.go
@@ -11,10 +11,6 @@ const (
 	//
 	// https://github.com/theupdateframework/specification
 	//
-	// Unfortunately there was a bug in the 1.0 spec, which reused the 0.9
-	// key ids. This patch fixes it:
-	//
-	// https://github.com/theupdateframework/specification/pull/43
 	public       = `"72378e5bc588793e58f81c8533da64a2e8f1565c1fcc7f253496394ffc52542c"`
 	keyid10      = "1bf1c6e3cdd3d3a8420b19199e27511999850f4b376c4547b2f32fba7e80fca3"
 	keyid10algos = "506a349b85945d0d99c7289c3f0f1f6c550218089d1d38a3f64824db31e827ac"

--- a/repo.go
+++ b/repo.go
@@ -108,7 +108,15 @@ func (r *Repo) db() (*verify.DB, error) {
 	}
 	for id, k := range root.Keys {
 		if err := db.AddKey(id, k); err != nil {
-			return nil, err
+			// TUF is considering in TAP-12 removing the
+			// requirement that the keyid hash algorithm be derived
+			// from the public key. So to be forwards compatible,
+			// we ignore `ErrWrongID` errors.
+			//
+			// TAP-12: https://github.com/theupdateframework/taps/blob/master/tap12.md
+			if _, ok := err.(verify.ErrWrongID); !ok {
+				return nil, err
+			}
 		}
 	}
 	for name, role := range root.Roles {

--- a/repo_test.go
+++ b/repo_test.go
@@ -1357,8 +1357,7 @@ func (rs *RepoSuite) TestUnknownKeyIDs(c *C) {
 	c.Assert(ok, Equals, true)
 	c.Assert(unknownKey, DeepEquals, key.PublicData())
 
-	// make sure if we generate a new root that we preserve the unknown key
-	// id.
+	// a new root should preserve the unknown key id.
 	root, err = r.root()
 
 	genKey(c, r, "timestamp")


### PR DESCRIPTION
In [TAP-12], we're considering removing the requirement that keyids are derived using `hexdigest(sha256(cjson(public_key_data)))`. This patch updates go-tuf to ignore, rather than fail out, if we see a keyid that wasn't derived with this algorithm. This makes us both forward compatible to TUF-1.0, and backwards-compatible with go-tuf's hybrid 0.9/1.0 transition.

Test: Added tests that make sure repos can generate new versions of metadata and preserve unknown keyids, and that clients ignore repos with random string keyids.

[TAP-12]: https://github.com/theupdateframework/taps/blob/master/tap12.md
