### PR TITLE
[types] add custom json message to keyval

### DIFF
--- a/data/types.go
+++ b/data/types.go
@@ -61,7 +61,8 @@ func (k *Key) ContainsID(id string) bool {
 }
 
 type KeyValue struct {
-	Public HexBytes `json:"public"`
+	Public HexBytes         `json:"public"`
+	Custom *json.RawMessage `json:"custom,omitempty"`
 }
 
 func DefaultExpires(role string) time.Time {

--- a/data/types_test.go
+++ b/data/types_test.go
@@ -11,9 +11,10 @@ const (
 	//
 	// https://github.com/theupdateframework/specification
 	//
-	public       = `"72378e5bc588793e58f81c8533da64a2e8f1565c1fcc7f253496394ffc52542c"`
-	keyid10      = "1bf1c6e3cdd3d3a8420b19199e27511999850f4b376c4547b2f32fba7e80fca3"
-	keyid10algos = "506a349b85945d0d99c7289c3f0f1f6c550218089d1d38a3f64824db31e827ac"
+	public        = `"72378e5bc588793e58f81c8533da64a2e8f1565c1fcc7f253496394ffc52542c"`
+	keyid10       = "1bf1c6e3cdd3d3a8420b19199e27511999850f4b376c4547b2f32fba7e80fca3"
+	keyid10algos  = "506a349b85945d0d99c7289c3f0f1f6c550218089d1d38a3f64824db31e827ac"
+	keyid10custom = "c96b968027adf3d30470ba5dbff221f5fb4caf754868b58a0f3648f28949550f"
 )
 
 type TypesSuite struct{}
@@ -90,4 +91,39 @@ func (TypesSuite) TestRoleAddKeyIDs(c *C) {
 	// Adding the key again doesn't modify the array.
 	c.Assert(role.AddKeyIDs(key.IDs()), Equals, true)
 	c.Assert(role.KeyIDs, DeepEquals, []string{keyid10, keyid10algos})
+}
+
+func (TypesSuite) TestRoleAddKeyCustom(c *C) {
+	var hexbytes HexBytes
+	err := json.Unmarshal([]byte(public), &hexbytes)
+	c.Assert(err, IsNil)
+
+	custom := json.RawMessage(`{"foo":"bar"}`)
+	key := &Key{
+		Type:   KeyTypeEd25519,
+		Scheme: KeySchemeEd25519,
+		Value:  KeyValue{Public: hexbytes, Custom: &custom},
+	}
+
+	role := &Role{}
+	c.Assert(role.KeyIDs, HasLen, 0)
+
+	c.Assert(role.AddKeyIDs(key.IDs()), Equals, true)
+	c.Assert(role.KeyIDs, DeepEquals, []string{keyid10custom})
+
+	// Adding the key again doesn't modify the array.
+	c.Assert(role.AddKeyIDs(key.IDs()), Equals, false)
+	c.Assert(role.KeyIDs, DeepEquals, []string{keyid10custom})
+
+	// Add another key without custom data.
+	key = &Key{
+		Type:       KeyTypeEd25519,
+		Scheme:     KeySchemeEd25519,
+		Algorithms: KeyAlgorithms,
+		Value:      KeyValue{Public: hexbytes},
+	}
+
+	// Adding the key again doesn't modify the array.
+	c.Assert(role.AddKeyIDs(key.IDs()), Equals, true)
+	c.Assert(role.KeyIDs, DeepEquals, []string{keyid10custom, keyid10algos})
 }


### PR DESCRIPTION
This adds a custom json message to `KeyValue`. By the specification, `KeyValue` must contain the public data associated with the key, and here I'd like to extend it to include information other than the Public bytes associated with the key:

I'd like to include a hardware and device cert for the offline keys generated, and attach their certificates in the KeyValue in the root metadata. It seems appropriate to attach it to the Key. 

WDYT? Happy to make a PR in the python repository as well, the change will actually need to be in securesystemslib https://github.com/secure-systems-lab/securesystemslib/blob/1983feda61da8a9ce8c6d2bc0955c1d2be08ad6f/securesystemslib/formats.py#L179

Signed-off-by: Asra Ali <asraa@google.com>