### PR TITLE
Add the ability to sign with an external tool (Dump signable content + append signature)

### DIFF
--- a/repo.go
+++ b/repo.go
@@ -551,7 +551,7 @@ func (r *Repo) AppendSignature(name string, signature data.Signature) error {
 		return ErrInvalidRole{role}
 	}
 	if !roleData.ValidKey(signature.KeyID) {
-		return verify.ErrInvalidKeyID
+		return verify.ErrInvalidKey
 	}
 
 	s, err := r.SignedMeta(name)

--- a/repo_test.go
+++ b/repo_test.go
@@ -1540,11 +1540,20 @@ func (rs *RepoSuite) TestBadAppendSignatures(c *C) {
 			Signature: rootSig}), Equals, ErrInvalidRole{"invalid_root"})
 	}
 
-	// add a root signature with an invalid key ID
+	// add a root signature with an key ID that is for the targets role
 	for _, id := range targetsKey.Signer().IDs() {
 		c.Assert(r.AppendSignature("root.json", data.Signature{
 			KeyID:     id,
 			Signature: rootSig}), Equals, verify.ErrInvalidKey)
+	}
+
+	// attempt to add a bad signature to root
+	badSig, err := rootKey.Signer().Sign(rand.Reader, []byte(""), crypto.Hash(0))
+	c.Assert(err, IsNil)
+	for _, id := range rootKey.Signer().IDs() {
+		c.Assert(r.AppendSignature("root.json", data.Signature{
+			KeyID:     id,
+			Signature: badSig}), Equals, verify.ErrInvalid)
 	}
 
 	// add the correct root signature

--- a/repo_test.go
+++ b/repo_test.go
@@ -1,6 +1,8 @@
 package tuf
 
 import (
+	"crypto"
+	"crypto/rand"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1429,4 +1431,77 @@ func (rs *RepoSuite) TestThreshold(c *C) {
 	timestampVersion, err := r.TimestampVersion()
 	c.Assert(err, IsNil)
 	c.Assert(timestampVersion, Equals, 2)
+}
+
+func (rs *RepoSuite) TestAppendSignatures(c *C) {
+	files := map[string][]byte{"foo.txt": []byte("foo")}
+	local := MemoryStore(make(map[string]json.RawMessage), files)
+	r, err := NewRepo(local)
+	c.Assert(err, IsNil)
+
+	// don't use consistent snapshots to make the checks simpler
+	c.Assert(r.Init(false), IsNil)
+
+	// generate root key offline and add as a verification key
+	rootKey, err := sign.GenerateEd25519Key()
+	c.Assert(err, IsNil)
+	c.Assert(r.AddVerificationKey("root", rootKey.PublicData()), IsNil)
+	targetsKey, err := sign.GenerateEd25519Key()
+	c.Assert(err, IsNil)
+	c.Assert(r.AddVerificationKey("targets", targetsKey.PublicData()), IsNil)
+	snapshotKey, err := sign.GenerateEd25519Key()
+	c.Assert(err, IsNil)
+	c.Assert(r.AddVerificationKey("snapshot", snapshotKey.PublicData()), IsNil)
+	timestampKey, err := sign.GenerateEd25519Key()
+	c.Assert(err, IsNil)
+	c.Assert(r.AddVerificationKey("timestamp", timestampKey.PublicData()), IsNil)
+
+	// generate signatures externally and append
+	rootMeta, err := r.SignedMeta("root.json")
+	c.Assert(err, IsNil)
+	rootSig, err := rootKey.Signer().Sign(rand.Reader, rootMeta.Signed, crypto.Hash(0))
+	c.Assert(err, IsNil)
+	for _, id := range rootKey.Signer().IDs() {
+		c.Assert(r.AppendSignature("root.json", data.Signature{
+			KeyID:     id,
+			Signature: rootSig}), IsNil)
+	}
+
+	// add targets and sign
+	c.Assert(r.AddTarget("foo.txt", nil), IsNil)
+	targetsMeta, err := r.SignedMeta("targets.json")
+	c.Assert(err, IsNil)
+	targetsSig, err := targetsKey.Signer().Sign(rand.Reader, targetsMeta.Signed, crypto.Hash(0))
+	c.Assert(err, IsNil)
+	for _, id := range targetsKey.Signer().IDs() {
+		r.AppendSignature("targets.json", data.Signature{
+			KeyID:     id,
+			Signature: targetsSig})
+	}
+
+	// snapshot and timestamp
+	c.Assert(r.Snapshot(CompressionTypeNone), IsNil)
+	snapshotMeta, err := r.SignedMeta("snapshot.json")
+	c.Assert(err, IsNil)
+	snapshotSig, err := snapshotKey.Signer().Sign(rand.Reader, snapshotMeta.Signed, crypto.Hash(0))
+	c.Assert(err, IsNil)
+	for _, id := range snapshotKey.Signer().IDs() {
+		r.AppendSignature("snapshot.json", data.Signature{
+			KeyID:     id,
+			Signature: snapshotSig})
+	}
+
+	c.Assert(r.Timestamp(), IsNil)
+	timestampMeta, err := r.SignedMeta("timestamp.json")
+	c.Assert(err, IsNil)
+	timestampSig, err := timestampKey.Signer().Sign(rand.Reader, timestampMeta.Signed, crypto.Hash(0))
+	c.Assert(err, IsNil)
+	for _, id := range timestampKey.Signer().IDs() {
+		r.AppendSignature("timestamp.json", data.Signature{
+			KeyID:     id,
+			Signature: timestampSig})
+	}
+
+	// commit successfully!
+	c.Assert(r.Commit(), IsNil)
 }

--- a/repo_test.go
+++ b/repo_test.go
@@ -1433,7 +1433,7 @@ func (rs *RepoSuite) TestThreshold(c *C) {
 	c.Assert(timestampVersion, Equals, 2)
 }
 
-func (rs *RepoSuite) TestAppendSignatures(c *C) {
+func (rs *RepoSuite) TestAddOrUpdateSignatures(c *C) {
 	files := map[string][]byte{"foo.txt": []byte("foo")}
 	local := MemoryStore(make(map[string]json.RawMessage), files)
 	r, err := NewRepo(local)
@@ -1462,7 +1462,7 @@ func (rs *RepoSuite) TestAppendSignatures(c *C) {
 	rootSig, err := rootKey.Signer().Sign(rand.Reader, rootMeta.Signed, crypto.Hash(0))
 	c.Assert(err, IsNil)
 	for _, id := range rootKey.Signer().IDs() {
-		c.Assert(r.AppendSignature("root.json", data.Signature{
+		c.Assert(r.AddOrUpdateSignature("root.json", data.Signature{
 			KeyID:     id,
 			Signature: rootSig}), IsNil)
 	}
@@ -1474,7 +1474,7 @@ func (rs *RepoSuite) TestAppendSignatures(c *C) {
 	targetsSig, err := targetsKey.Signer().Sign(rand.Reader, targetsMeta.Signed, crypto.Hash(0))
 	c.Assert(err, IsNil)
 	for _, id := range targetsKey.Signer().IDs() {
-		r.AppendSignature("targets.json", data.Signature{
+		r.AddOrUpdateSignature("targets.json", data.Signature{
 			KeyID:     id,
 			Signature: targetsSig})
 	}
@@ -1486,7 +1486,7 @@ func (rs *RepoSuite) TestAppendSignatures(c *C) {
 	snapshotSig, err := snapshotKey.Signer().Sign(rand.Reader, snapshotMeta.Signed, crypto.Hash(0))
 	c.Assert(err, IsNil)
 	for _, id := range snapshotKey.Signer().IDs() {
-		r.AppendSignature("snapshot.json", data.Signature{
+		r.AddOrUpdateSignature("snapshot.json", data.Signature{
 			KeyID:     id,
 			Signature: snapshotSig})
 	}
@@ -1497,7 +1497,7 @@ func (rs *RepoSuite) TestAppendSignatures(c *C) {
 	timestampSig, err := timestampKey.Signer().Sign(rand.Reader, timestampMeta.Signed, crypto.Hash(0))
 	c.Assert(err, IsNil)
 	for _, id := range timestampKey.Signer().IDs() {
-		r.AppendSignature("timestamp.json", data.Signature{
+		r.AddOrUpdateSignature("timestamp.json", data.Signature{
 			KeyID:     id,
 			Signature: timestampSig})
 	}
@@ -1506,7 +1506,7 @@ func (rs *RepoSuite) TestAppendSignatures(c *C) {
 	c.Assert(r.Commit(), IsNil)
 }
 
-func (rs *RepoSuite) TestBadAppendSignatures(c *C) {
+func (rs *RepoSuite) TestBadAddOrUpdateSignatures(c *C) {
 	files := map[string][]byte{"foo.txt": []byte("foo")}
 	local := MemoryStore(make(map[string]json.RawMessage), files)
 	r, err := NewRepo(local)
@@ -1535,14 +1535,14 @@ func (rs *RepoSuite) TestBadAppendSignatures(c *C) {
 	rootSig, err := rootKey.Signer().Sign(rand.Reader, rootMeta.Signed, crypto.Hash(0))
 	c.Assert(err, IsNil)
 	for _, id := range rootKey.Signer().IDs() {
-		c.Assert(r.AppendSignature("invalid_root.json", data.Signature{
+		c.Assert(r.AddOrUpdateSignature("invalid_root.json", data.Signature{
 			KeyID:     id,
 			Signature: rootSig}), Equals, ErrInvalidRole{"invalid_root"})
 	}
 
 	// add a root signature with an key ID that is for the targets role
 	for _, id := range targetsKey.Signer().IDs() {
-		c.Assert(r.AppendSignature("root.json", data.Signature{
+		c.Assert(r.AddOrUpdateSignature("root.json", data.Signature{
 			KeyID:     id,
 			Signature: rootSig}), Equals, verify.ErrInvalidKey)
 	}
@@ -1551,14 +1551,14 @@ func (rs *RepoSuite) TestBadAppendSignatures(c *C) {
 	badSig, err := rootKey.Signer().Sign(rand.Reader, []byte(""), crypto.Hash(0))
 	c.Assert(err, IsNil)
 	for _, id := range rootKey.Signer().IDs() {
-		c.Assert(r.AppendSignature("root.json", data.Signature{
+		c.Assert(r.AddOrUpdateSignature("root.json", data.Signature{
 			KeyID:     id,
 			Signature: badSig}), Equals, verify.ErrInvalid)
 	}
 
 	// add the correct root signature
 	for _, id := range rootKey.Signer().IDs() {
-		c.Assert(r.AppendSignature("root.json", data.Signature{
+		c.Assert(r.AddOrUpdateSignature("root.json", data.Signature{
 			KeyID:     id,
 			Signature: rootSig}), IsNil)
 	}
@@ -1574,7 +1574,7 @@ func (rs *RepoSuite) TestBadAppendSignatures(c *C) {
 
 	// re-adding should not duplicate
 	for _, id := range rootKey.Signer().IDs() {
-		c.Assert(r.AppendSignature("root.json", data.Signature{
+		c.Assert(r.AddOrUpdateSignature("root.json", data.Signature{
 			KeyID:     id,
 			Signature: rootSig}), IsNil)
 	}


### PR DESCRIPTION
Allows users to sign content with an external tool. Required
* Making `SignedMeta` public to access the signable content as the payload to sign
* AppendSignature: adds a signature to the metadata. Checks that this is a valid key for the role and replaces existing sigs with the same ID
* Adding a method to add a verification key, similar to the python reference implementation. This adds the public key data for a role to the root metadata without needing the private key

Signed-off-by: Asra Ali <asraa@google.com>