### PR TITLE
Make targetsWalkFunc public

### DIFF
--- a/local_store.go
+++ b/local_store.go
@@ -50,7 +50,7 @@ func (m *memoryStore) SetMeta(name string, meta json.RawMessage) error {
 	return nil
 }
 
-func (m *memoryStore) WalkStagedTargets(paths []string, targetsFn targetsWalkFunc) error {
+func (m *memoryStore) WalkStagedTargets(paths []string, targetsFn TargetsWalkFunc) error {
 	if len(paths) == 0 {
 		for path, data := range m.files {
 			if err := targetsFn(path, bytes.NewReader(data)); err != nil {
@@ -166,7 +166,7 @@ func (f *fileSystemStore) createDirs() error {
 	return nil
 }
 
-func (f *fileSystemStore) WalkStagedTargets(paths []string, targetsFn targetsWalkFunc) error {
+func (f *fileSystemStore) WalkStagedTargets(paths []string, targetsFn TargetsWalkFunc) error {
 	if len(paths) == 0 {
 		walkFunc := func(path string, info os.FileInfo, err error) error {
 			if err != nil {

--- a/repo.go
+++ b/repo.go
@@ -36,7 +36,7 @@ var snapshotManifests = []string{
 	"targets.json",
 }
 
-type targetsWalkFunc func(path string, target io.Reader) error
+type TargetsWalkFunc func(path string, target io.Reader) error
 
 type LocalStore interface {
 	GetMeta() (map[string]json.RawMessage, error)
@@ -45,7 +45,7 @@ type LocalStore interface {
 	// WalkStagedTargets calls targetsFn for each staged target file in paths.
 	//
 	// If paths is empty, all staged target files will be walked.
-	WalkStagedTargets(paths []string, targetsFn targetsWalkFunc) error
+	WalkStagedTargets(paths []string, targetsFn TargetsWalkFunc) error
 
 	Commit(bool, map[string]int, map[string]data.Hashes) error
 	GetSigningKeys(string) ([]sign.Signer, error)

--- a/repo.go
+++ b/repo.go
@@ -36,6 +36,9 @@ var snapshotManifests = []string{
 	"targets.json",
 }
 
+// TargetsWalkFunc is a function of a target path name and a target payload used to
+// execute some function on each staged target file. For example, it may normalize path
+// names and generate target file metadata with additional custom metadata.
 type TargetsWalkFunc func(path string, target io.Reader) error
 
 type LocalStore interface {

--- a/repo.go
+++ b/repo.go
@@ -39,7 +39,10 @@ var snapshotManifests = []string{
 type TargetsWalkFunc func(path string, target io.Reader) error
 
 type LocalStore interface {
+	// GetMeta returns a map from manifest file names (e.g. root.json) to their raw JSON payload or an error.
 	GetMeta() (map[string]json.RawMessage, error)
+
+	// SetMeta is used to update a manifest file name with a JSON payload.
 	SetMeta(string, json.RawMessage) error
 
 	// WalkStagedTargets calls targetsFn for each staged target file in paths.
@@ -47,9 +50,16 @@ type LocalStore interface {
 	// If paths is empty, all staged target files will be walked.
 	WalkStagedTargets(paths []string, targetsFn TargetsWalkFunc) error
 
+	// Commit is used to publish staged files to the repository
 	Commit(bool, map[string]int, map[string]data.Hashes) error
+
+	// GetSigningKeys return a list of signing keys for a role.
 	GetSigningKeys(string) ([]sign.Signer, error)
+
+	// SavePrivateKey adds a signing key to a role.
 	SavePrivateKey(string, *sign.PrivateKey) error
+
+	// Clean is used to remove all staged manifests.
 	Clean() error
 }
 


### PR DESCRIPTION
In order to implement a custom LocalStore, you will need to reference targetsWalkFunc, which is currently private. Make this public so custom LocalStores can be implemented in external libraries.

Signed-off-by: Asra Ali <asraa@google.com>