### PR TITLE
Generalize "keyval" data to be any custom JSON containing public portion of key

### DIFF
--- a/client/python_interop/python_interop_test.go
+++ b/client/python_interop/python_interop_test.go
@@ -16,6 +16,7 @@ import (
 	client "github.com/theupdateframework/go-tuf/client"
 	"github.com/theupdateframework/go-tuf/data"
 	"github.com/theupdateframework/go-tuf/util"
+	"github.com/theupdateframework/go-tuf/verify"
 	"golang.org/x/crypto/ed25519"
 	. "gopkg.in/check.v1"
 )
@@ -64,7 +65,10 @@ func (InteropSuite) TestGoClientPythonGenerated(c *C) {
 		key := &data.Key{}
 		c.Assert(json.NewDecoder(f).Decode(key), IsNil)
 		c.Assert(key.Type, Equals, "ed25519")
-		c.Assert(key.Value.Public, HasLen, ed25519.PublicKeySize)
+		v := verify.Verifiers[key.Type]
+		pubBytes, err := v.Public(key.Value)
+		c.Assert(err, IsNil)
+		c.Assert(pubBytes, HasLen, ed25519.PublicKeySize)
 		client := client.NewClient(client.MemoryLocalStore(), remote)
 		c.Assert(client.Init([]*data.Key{key}, 1), IsNil)
 

--- a/data/types.go
+++ b/data/types.go
@@ -42,9 +42,9 @@ type Key struct {
 	idOnce sync.Once
 }
 
-// A KeyType instance is an implementation of a KeyType
+// A KeyType implements type-specific methods for the Key data type.
 type KeyType interface {
-	// UniquePublic returns the unique information identifying the public key from the KeyValue.
+	// UniquePublic returns the unique information identifying the public key from the KeyValue dictionary.
 	UniquePublic(valueBytes json.RawMessage) string
 }
 

--- a/data/types_test.go
+++ b/data/types_test.go
@@ -25,10 +25,12 @@ func (TypesSuite) TestKeyIDs(c *C) {
 	err := json.Unmarshal([]byte(public), &hexbytes)
 	c.Assert(err, IsNil)
 
+	pubBytes, err := json.Marshal(KeyValue{Public: hexbytes})
+	c.Assert(err, IsNil)
 	key := Key{
 		Type:   KeyTypeEd25519,
 		Scheme: KeySchemeEd25519,
-		Value:  KeyValue{Public: hexbytes},
+		Value:  pubBytes,
 	}
 	c.Assert(key.IDs(), DeepEquals, []string{keyid10})
 
@@ -36,7 +38,7 @@ func (TypesSuite) TestKeyIDs(c *C) {
 		Type:       KeyTypeEd25519,
 		Scheme:     KeySchemeEd25519,
 		Algorithms: KeyAlgorithms,
-		Value:      KeyValue{Public: hexbytes},
+		Value:      pubBytes,
 	}
 	c.Assert(key.IDs(), DeepEquals, []string{keyid10algos})
 }
@@ -46,10 +48,12 @@ func (TypesSuite) TestRootAddKey(c *C) {
 	err := json.Unmarshal([]byte(public), &hexbytes)
 	c.Assert(err, IsNil)
 
+	pubBytes, err := json.Marshal(KeyValue{Public: hexbytes})
+	c.Assert(err, IsNil)
 	key := &Key{
 		Type:   KeyTypeEd25519,
 		Scheme: KeySchemeEd25519,
-		Value:  KeyValue{Public: hexbytes},
+		Value:  pubBytes,
 	}
 
 	root := NewRoot()
@@ -63,10 +67,12 @@ func (TypesSuite) TestRoleAddKeyIDs(c *C) {
 	err := json.Unmarshal([]byte(public), &hexbytes)
 	c.Assert(err, IsNil)
 
+	pubBytes, err := json.Marshal(KeyValue{Public: hexbytes})
+	c.Assert(err, IsNil)
 	key := &Key{
 		Type:   KeyTypeEd25519,
 		Scheme: KeySchemeEd25519,
-		Value:  KeyValue{Public: hexbytes},
+		Value:  pubBytes,
 	}
 
 	role := &Role{}
@@ -84,7 +90,7 @@ func (TypesSuite) TestRoleAddKeyIDs(c *C) {
 		Type:       KeyTypeEd25519,
 		Scheme:     KeySchemeEd25519,
 		Algorithms: KeyAlgorithms,
-		Value:      KeyValue{Public: hexbytes},
+		Value:      pubBytes,
 	}
 
 	// Adding the key again doesn't modify the array.

--- a/repo_test.go
+++ b/repo_test.go
@@ -172,7 +172,10 @@ func (rs *RepoSuite) TestGenKey(c *C) {
 			c.Fatal("missing key")
 		}
 		c.Assert(k.IDs(), DeepEquals, ids)
-		c.Assert(k.Value.Public, HasLen, ed25519.PublicKeySize)
+		v := verify.Verifiers[k.Type]
+		pub, err := v.Public(k.Value)
+		c.Assert(err, IsNil)
+		c.Assert(pub, HasLen, ed25519.PublicKeySize)
 	}
 
 	// check root key + role are in db
@@ -196,7 +199,13 @@ func (rs *RepoSuite) TestGenKey(c *C) {
 		c.Assert(err, IsNil)
 		c.Assert(rootKeys, HasLen, 1)
 		c.Assert(rootKeys[0].IDs(), DeepEquals, rootKey.IDs())
-		c.Assert(rootKeys[0].Value.Public, DeepEquals, rootKey.Value.Public)
+		v0 := verify.Verifiers[rootKeys[0].Type]
+		pub0, err := v0.Public(rootKeys[0].Value)
+		c.Assert(err, IsNil)
+		v := verify.Verifiers[rootKey.Type]
+		pub, err := v.Public(rootKey.Value)
+		c.Assert(err, IsNil)
+		c.Assert(pub0, DeepEquals, pub)
 	}
 
 	rootKey := db.GetKey(ids[0])
@@ -331,7 +340,10 @@ func (rs *RepoSuite) TestAddPrivateKey(c *C) {
 			c.Fatalf("missing key %s", keyID)
 		}
 		c.Assert(k.IDs(), DeepEquals, ids)
-		c.Assert(k.Value.Public, HasLen, ed25519.PublicKeySize)
+		v := verify.Verifiers[k.Type]
+		pub, err := v.Public(k.Value)
+		c.Assert(err, IsNil)
+		c.Assert(pub, HasLen, ed25519.PublicKeySize)
 	}
 
 	// check root key + role are in db
@@ -355,7 +367,13 @@ func (rs *RepoSuite) TestAddPrivateKey(c *C) {
 		c.Assert(err, IsNil)
 		c.Assert(rootKeys, HasLen, 1)
 		c.Assert(rootKeys[0].IDs(), DeepEquals, rootKey.IDs())
-		c.Assert(rootKeys[0].Value.Public, DeepEquals, rootKey.Value.Public)
+		v0 := verify.Verifiers[rootKeys[0].Type]
+		pub0, err := v0.Public(rootKeys[0].Value)
+		c.Assert(err, IsNil)
+		v := verify.Verifiers[rootKey.Type]
+		pub, err := v.Public(rootKey.Value)
+		c.Assert(err, IsNil)
+		c.Assert(pub0, DeepEquals, pub)
 	}
 
 	rootKey := db.GetKey(ids[0])

--- a/sign/keys.go
+++ b/sign/keys.go
@@ -2,6 +2,7 @@ package sign
 
 import (
 	"crypto/rand"
+	"encoding/json"
 	"sync"
 
 	"github.com/theupdateframework/go-tuf/data"
@@ -21,11 +22,12 @@ type PrivateKeyValue struct {
 }
 
 func (k *PrivateKey) PublicData() *data.Key {
+	keyValBytes, _ := json.Marshal(data.KeyValue{Public: k.Value.Public})
 	return &data.Key{
 		Type:       k.Type,
 		Scheme:     k.Scheme,
 		Algorithms: k.Algorithms,
-		Value:      data.KeyValue{Public: k.Value.Public},
+		Value:      keyValBytes,
 	}
 }
 
@@ -81,11 +83,12 @@ func (s *ed25519Signer) ContainsID(id string) bool {
 }
 
 func (s *ed25519Signer) publicData() *data.Key {
+	keyValBytes, _ := json.Marshal(data.KeyValue{Public: []byte(s.PrivateKey.Public().(ed25519.PublicKey))})
 	return &data.Key{
 		Type:       s.keyType,
 		Scheme:     s.keyScheme,
 		Algorithms: s.keyAlgorithms,
-		Value:      data.KeyValue{Public: []byte(s.PrivateKey.Public().(ed25519.PublicKey))},
+		Value:      keyValBytes,
 	}
 }
 

--- a/verify/db.go
+++ b/verify/db.go
@@ -34,7 +34,11 @@ func (db *DB) AddKey(id string, k *data.Key) error {
 	if !k.ContainsID(id) {
 		return ErrWrongID{}
 	}
-	if !v.ValidKey(k.Value.Public) {
+	public, err := v.Public(k.Value)
+	if err != nil {
+		return err
+	}
+	if !v.ValidKey(public) {
 		return ErrInvalidKey
 	}
 

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -74,7 +74,12 @@ func (db *DB) VerifySignatures(s *data.Signed, role string) error {
 			continue
 		}
 
-		if err := Verifiers[key.Type].Verify(key.Value.Public, msg, sig.Signature); err != nil {
+		verifier := Verifiers[key.Type]
+		pubBytes, err := verifier.Public(key.Value)
+		if err != nil {
+			return err
+		}
+		if err := verifier.Verify(pubBytes, msg, sig.Signature); err != nil {
 			return err
 		}
 

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/sha256"
+	"encoding/json"
 	"io"
 	"testing"
 	"time"
@@ -30,11 +31,12 @@ type ecdsaSigner struct {
 
 func (s ecdsaSigner) PublicData() *data.Key {
 	pub := s.Public().(*ecdsa.PublicKey)
+	keyValBytes, _ := json.Marshal(data.KeyValue{Public: elliptic.Marshal(pub.Curve, pub.X, pub.Y)})
 	return &data.Key{
 		Type:       data.KeyTypeECDSA_SHA2_P256,
 		Scheme:     data.KeySchemeECDSA_SHA2_P256,
 		Algorithms: data.KeyAlgorithms,
-		Value:      data.KeyValue{Public: elliptic.Marshal(pub.Curve, pub.X, pub.Y)},
+		Value:      keyValBytes,
 	}
 }
 


### PR DESCRIPTION
Admittedly, all keys currently just contain a `public` field. This customizes it for key types (e.g. Fulcio) that may have other information in their public field (issuer, email).

THIS IS NOT THE BEST WAY TO DO IT! I'm considering an overhaul of the key types. Would love suggestions if you have a clear vision for it

Signed-off-by: Asra Ali <asraa@google.com>