### PR TITLE
Look for target in delegations

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -714,7 +714,8 @@ func (c *Client) Download(name string, dest Destination) (err error) {
 }
 
 // Target returns the target metadata for a specific target if it
-// exists. If it does not, ErrNotFound will be returned.
+// exists, searching from top-level level targets then through
+// all delegations. If it does not, ErrNotFound will be returned.
 func (c *Client) Target(name string) (data.TargetFileMeta, error) {
 	target, err := c.getTargetFileMeta(util.NormalizeTarget(name))
 	if err == nil {
@@ -728,7 +729,7 @@ func (c *Client) Target(name string) (data.TargetFileMeta, error) {
 	return data.TargetFileMeta{}, err
 }
 
-// Targets returns the complete list of available targets.
+// Targets returns the complete list of available top-level targets.
 func (c *Client) Targets() (data.TargetFiles, error) {
 	// populate c.targets from local storage if not set
 	if c.targets == nil {

--- a/client/client.go
+++ b/client/client.go
@@ -716,21 +716,16 @@ func (c *Client) Download(name string, dest Destination) (err error) {
 // Target returns the target metadata for a specific target if it
 // exists. If it does not, ErrNotFound will be returned.
 func (c *Client) Target(name string) (data.TargetFileMeta, error) {
-	m, err := c.Targets()
-	if err != nil {
-		return data.TargetFileMeta{}, err
-	}
-
-	target, ok := m[util.NormalizeTarget(name)]
-	if ok {
+	target, err := c.getTargetFileMeta(util.NormalizeTarget(name))
+	if err == nil {
 		return target, nil
 	}
 
-	if target, err = c.getTargetFileMeta(name); err == nil {
-		return target, nil
+	if _, ok := err.(ErrUnknownTarget); ok {
+		return data.TargetFileMeta{}, ErrNotFound{name}
 	}
 
-	return data.TargetFileMeta{}, ErrNotFound{name}
+	return data.TargetFileMeta{}, err
 }
 
 // Targets returns the complete list of available targets.

--- a/client/client.go
+++ b/client/client.go
@@ -726,6 +726,10 @@ func (c *Client) Target(name string) (data.TargetFileMeta, error) {
 		return target, nil
 	}
 
+	if target, err = c.getTargetFileMeta(name); err == nil {
+		return target, nil
+	}
+
 	return data.TargetFileMeta{}, ErrNotFound{name}
 }
 

--- a/client/delegations_test.go
+++ b/client/delegations_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/theupdateframework/go-tuf/data"
+	"github.com/theupdateframework/go-tuf/util"
 	"github.com/theupdateframework/go-tuf/verify"
 )
 
@@ -311,6 +312,7 @@ func TestPersistedMeta(t *testing.T) {
 		file          string
 		targets       []expectedTargets
 		downloadError error
+		targetError   error
 		fileContent   string
 	}{
 		{
@@ -322,6 +324,7 @@ func TestPersistedMeta(t *testing.T) {
 				},
 			},
 			downloadError: ErrUnknownTarget{Name: "unknown", SnapshotVersion: 2},
+			targetError:   ErrNotFound{File: "unknown"},
 			fileContent:   "",
 		},
 		{
@@ -341,6 +344,7 @@ func TestPersistedMeta(t *testing.T) {
 				},
 			},
 			downloadError: nil,
+			targetError:   nil,
 			fileContent:   "Contents: b.txt",
 		},
 		{
@@ -376,6 +380,7 @@ func TestPersistedMeta(t *testing.T) {
 				},
 			},
 			downloadError: nil,
+			targetError:   nil,
 			fileContent:   "Contents: f.txt",
 		},
 	}
@@ -386,6 +391,14 @@ func TestPersistedMeta(t *testing.T) {
 			err = c.Download(tt.file, &dest)
 			assert.Equal(t, tt.downloadError, err)
 			assert.Equal(t, tt.fileContent, dest.String())
+
+			target, err := c.Target(tt.file)
+			assert.Equal(t, tt.targetError, err)
+			if tt.targetError == nil {
+				meta, err := util.GenerateTargetFileMeta(strings.NewReader(tt.fileContent), target.HashAlgorithms()...)
+				assert.Nil(t, err)
+				assert.Nil(t, util.TargetFileMetaEqual(target, meta))
+			}
 
 			p, err := c.local.GetMeta()
 			assert.Nil(t, err)


### PR DESCRIPTION
When using delegations, a specific target file should be search among all the delegations targets