### PR TITLE
build: update go versions used in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.13.x, 1.14.x, 1.15.x]
+        go-version: [1.15.x, 1.16.x, 1.17.x]
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Our CI should be testing recent Go. Arguably we should not worry about
unsupported versions of Go.
According to the Go docs (https://golang.org/doc/devel/release):
"Each major Go release is supported until there are two newer major
releases."

Therefore, with current major Go being 1.17, update our CI to the three
supported verions -- 1.15, 1.16 and 1.17