### PR TITLE
Remove the --compression option when creating snapshots, ref. TAP10

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # go-tuf
-[![build](https://github.com/theupdateframework/go-tuf/workflows/build/badge.svg)](https://github.com/theupdateframework/go-tuf/actions?query=workflow%3Abuild) [![Coverage Status](https://coveralls.io/repos/github/theupdateframework/go-tuf/badge.svg)](https://coveralls.io/github/theupdateframework/go-tuf) [![PkgGoDev](https://pkg.go.dev/badge/github.com/theupdateframework/go-tuf)](https://pkg.go.dev/github.com/theupdateframework/go-tuf) [![Go Report Card](https://goreportcard.com/badge/github.com/theupdateframework/go-tuf)](https://goreportcard.com/report/github.com/theupdateframework/go-tuf)  
+
+[![build](https://github.com/theupdateframework/go-tuf/workflows/build/badge.svg)](https://github.com/theupdateframework/go-tuf/actions?query=workflow%3Abuild) [![Coverage Status](https://coveralls.io/repos/github/theupdateframework/go-tuf/badge.svg)](https://coveralls.io/github/theupdateframework/go-tuf) [![PkgGoDev](https://pkg.go.dev/badge/github.com/theupdateframework/go-tuf)](https://pkg.go.dev/github.com/theupdateframework/go-tuf) [![Go Report Card](https://goreportcard.com/badge/github.com/theupdateframework/go-tuf)](https://goreportcard.com/report/github.com/theupdateframework/go-tuf)
 
 This is a Go implementation of [The Update Framework (TUF)](http://theupdateframework.com/),
 a framework for securing software update systems.
@@ -19,11 +20,11 @@ A TUF repository has the following directory layout:
 
 The directories contain the following files:
 
-* `keys/` - signing keys (optionally encrypted) with filename pattern `ROLE.json`
-* `repository/` - signed manifests
-* `repository/targets/` - hashed target files
-* `staged/` - either signed, unsigned or partially signed manifests
-* `staged/targets/` - unhashed target files
+- `keys/` - signing keys (optionally encrypted) with filename pattern `ROLE.json`
+- `repository/` - signed manifests
+- `repository/targets/` - hashed target files
+- `staged/` - either signed, unsigned or partially signed manifests
+- `staged/targets/` - unhashed target files
 
 ## CLI
 
@@ -70,10 +71,11 @@ Stages the removal of files with the given path(s) from the `targets` manifest
 (they get removed from the filesystem when the change is committed). Specifying
 no paths removes all files from the `targets` manifest.
 
-#### `tuf snapshot [--compression=<format>]`
+#### `tuf snapshot [--expires=<days>]`
 
 Expects a staged, fully signed `targets` manifest and stages an appropriate
-`snapshot` manifest. It optionally compresses the staged `targets` manifest.
+`snapshot` manifest. Optionally one can set number of days after which
+the snapshot manifest to expire.
 
 #### `tuf timestamp`
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ no paths removes all files from the `targets` manifest.
 
 Expects a staged, fully signed `targets` manifest and stages an appropriate
 `snapshot` manifest. Optionally one can set number of days after which
-the snapshot manifest to expire.
+the snapshot manifest will expire.
 
 #### `tuf timestamp`
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -106,7 +106,7 @@ func (s *ClientSuite) SetUpTest(c *C) {
 		"timestamp": s.genKey(c, "timestamp"),
 	}
 	c.Assert(s.repo.AddTarget("foo.txt", nil), IsNil)
-	c.Assert(s.repo.Snapshot(tuf.CompressionTypeNone), IsNil)
+	c.Assert(s.repo.Snapshot(), IsNil)
 	c.Assert(s.repo.Timestamp(), IsNil)
 	c.Assert(s.repo.Commit(), IsNil)
 
@@ -162,7 +162,7 @@ func (s *ClientSuite) syncRemote(c *C) {
 
 func (s *ClientSuite) addRemoteTarget(c *C, name string) {
 	c.Assert(s.repo.AddTarget(name, nil), IsNil)
-	c.Assert(s.repo.Snapshot(tuf.CompressionTypeNone), IsNil)
+	c.Assert(s.repo.Snapshot(), IsNil)
 	c.Assert(s.repo.Timestamp(), IsNil)
 	c.Assert(s.repo.Commit(), IsNil)
 	s.syncRemote(c)
@@ -245,7 +245,7 @@ func (s *ClientSuite) TestInitRootTooLarge(c *C) {
 
 func (s *ClientSuite) TestInitRootExpired(c *C) {
 	s.genKeyExpired(c, "targets")
-	c.Assert(s.repo.Snapshot(tuf.CompressionTypeNone), IsNil)
+	c.Assert(s.repo.Snapshot(), IsNil)
 	c.Assert(s.repo.Timestamp(), IsNil)
 	c.Assert(s.repo.Commit(), IsNil)
 	s.syncRemote(c)
@@ -325,7 +325,7 @@ func (s *ClientSuite) TestNewRoot(c *C) {
 
 	// update metadata
 	c.Assert(s.repo.Sign("targets.json"), IsNil)
-	c.Assert(s.repo.Snapshot(tuf.CompressionTypeNone), IsNil)
+	c.Assert(s.repo.Snapshot(), IsNil)
 	c.Assert(s.repo.Timestamp(), IsNil)
 	c.Assert(s.repo.Commit(), IsNil)
 	s.syncRemote(c)
@@ -389,7 +389,7 @@ func (s *ClientSuite) TestNewTimestampKey(c *C) {
 	newIDs := s.genKey(c, "timestamp")
 
 	// generate new snapshot (because root has changed) and timestamp
-	c.Assert(s.repo.Snapshot(tuf.CompressionTypeNone), IsNil)
+	c.Assert(s.repo.Snapshot(), IsNil)
 	c.Assert(s.repo.Timestamp(), IsNil)
 	c.Assert(s.repo.Commit(), IsNil)
 	s.syncRemote(c)
@@ -426,7 +426,7 @@ func (s *ClientSuite) TestNewSnapshotKey(c *C) {
 	newIDs := s.genKey(c, "snapshot")
 
 	// generate new snapshot and timestamp
-	c.Assert(s.repo.Snapshot(tuf.CompressionTypeNone), IsNil)
+	c.Assert(s.repo.Snapshot(), IsNil)
 	c.Assert(s.repo.Timestamp(), IsNil)
 	c.Assert(s.repo.Commit(), IsNil)
 	s.syncRemote(c)
@@ -466,7 +466,7 @@ func (s *ClientSuite) TestNewTargetsKey(c *C) {
 
 	// re-sign targets and generate new snapshot and timestamp
 	c.Assert(s.repo.Sign("targets.json"), IsNil)
-	c.Assert(s.repo.Snapshot(tuf.CompressionTypeNone), IsNil)
+	c.Assert(s.repo.Snapshot(), IsNil)
 	c.Assert(s.repo.Timestamp(), IsNil)
 	c.Assert(s.repo.Commit(), IsNil)
 	s.syncRemote(c)
@@ -512,7 +512,7 @@ func (s *ClientSuite) TestLocalExpired(c *C) {
 
 	// locally expired snapshot.json is ok
 	version = client.snapshotVer
-	c.Assert(s.repo.SnapshotWithExpires(tuf.CompressionTypeNone, s.expiredTime), IsNil)
+	c.Assert(s.repo.SnapshotWithExpires(s.expiredTime), IsNil)
 	s.syncLocal(c)
 	s.withMetaExpired(func() {
 		c.Assert(client.getLocalMeta(), IsNil)
@@ -585,7 +585,7 @@ func (s *ClientSuite) TestUpdateRemoteExpired(c *C) {
 		s.assertErrExpired(c, err, "timestamp.json")
 	})
 
-	c.Assert(s.repo.SnapshotWithExpires(tuf.CompressionTypeNone, s.expiredTime), IsNil)
+	c.Assert(s.repo.SnapshotWithExpires(s.expiredTime), IsNil)
 	c.Assert(s.repo.Timestamp(), IsNil)
 	s.syncRemote(c)
 	s.withMetaExpired(func() {
@@ -594,7 +594,7 @@ func (s *ClientSuite) TestUpdateRemoteExpired(c *C) {
 	})
 
 	c.Assert(s.repo.AddTargetWithExpires("bar.txt", nil, s.expiredTime), IsNil)
-	c.Assert(s.repo.Snapshot(tuf.CompressionTypeNone), IsNil)
+	c.Assert(s.repo.Snapshot(), IsNil)
 	c.Assert(s.repo.Timestamp(), IsNil)
 	s.syncRemote(c)
 	s.withMetaExpired(func() {
@@ -604,7 +604,7 @@ func (s *ClientSuite) TestUpdateRemoteExpired(c *C) {
 
 	s.genKeyExpired(c, "timestamp")
 	c.Assert(s.repo.RemoveTarget("bar.txt"), IsNil)
-	c.Assert(s.repo.Snapshot(tuf.CompressionTypeNone), IsNil)
+	c.Assert(s.repo.Snapshot(), IsNil)
 	c.Assert(s.repo.Timestamp(), IsNil)
 	c.Assert(s.repo.Commit(), IsNil)
 	s.syncRemote(c)
@@ -631,7 +631,7 @@ func (s *ClientSuite) TestUpdateLocalRootExpiredKeyChange(c *C) {
 
 	// update metadata
 	c.Assert(s.repo.Sign("targets.json"), IsNil)
-	c.Assert(s.repo.Snapshot(tuf.CompressionTypeNone), IsNil)
+	c.Assert(s.repo.Snapshot(), IsNil)
 	c.Assert(s.repo.Timestamp(), IsNil)
 	c.Assert(s.repo.Commit(), IsNil)
 	s.syncRemote(c)
@@ -651,7 +651,7 @@ func (s *ClientSuite) TestUpdateMixAndMatchAttack(c *C) {
 	// generate metadata with an explicit expires so we can make predictable changes
 	expires := time.Now().Add(time.Hour)
 	c.Assert(s.repo.AddTargetWithExpires("foo.txt", nil, expires), IsNil)
-	c.Assert(s.repo.Snapshot(tuf.CompressionTypeNone), IsNil)
+	c.Assert(s.repo.Snapshot(), IsNil)
 	c.Assert(s.repo.Timestamp(), IsNil)
 	s.syncRemote(c)
 	client := s.updatedClient(c)
@@ -664,7 +664,7 @@ func (s *ClientSuite) TestUpdateMixAndMatchAttack(c *C) {
 
 	// generate new remote metadata, but replace targets.json with the old one
 	c.Assert(s.repo.AddTargetWithExpires("bar.txt", nil, expires), IsNil)
-	c.Assert(s.repo.Snapshot(tuf.CompressionTypeNone), IsNil)
+	c.Assert(s.repo.Snapshot(), IsNil)
 	c.Assert(s.repo.Timestamp(), IsNil)
 	s.syncRemote(c)
 	newTargets, ok := s.remote.meta["targets.json"]
@@ -679,7 +679,7 @@ func (s *ClientSuite) TestUpdateMixAndMatchAttack(c *C) {
 
 	// do the same but keep the size the same
 	c.Assert(s.repo.RemoveTargetWithExpires("foo.txt", expires), IsNil)
-	c.Assert(s.repo.Snapshot(tuf.CompressionTypeNone), IsNil)
+	c.Assert(s.repo.Snapshot(), IsNil)
 	c.Assert(s.repo.Timestamp(), IsNil)
 	s.syncRemote(c)
 	s.remote.meta["targets.json"] = oldTargets
@@ -937,7 +937,7 @@ func (s *ClientSuite) TestUnknownKeyIDs(c *C) {
 	// the TUF-0.9 update workflow, where we decide to update the root
 	// metadata when we observe a new root through the snapshot.
 	repo, err := tuf.NewRepo(s.store)
-	c.Assert(repo.Snapshot(tuf.CompressionTypeNone), IsNil)
+	c.Assert(repo.Snapshot(), IsNil)
 	c.Assert(repo.Timestamp(), IsNil)
 	c.Assert(repo.Commit(), IsNil)
 	s.syncRemote(c)
@@ -964,7 +964,7 @@ func generateRepoFS(c *C, dir string, files map[string][]byte, consistentSnapsho
 		c.Assert(ioutil.WriteFile(path, data, 0644), IsNil)
 		c.Assert(repo.AddTarget(file, nil), IsNil)
 	}
-	c.Assert(repo.Snapshot(tuf.CompressionTypeNone), IsNil)
+	c.Assert(repo.Snapshot(), IsNil)
 	c.Assert(repo.Timestamp(), IsNil)
 	c.Assert(repo.Commit(), IsNil)
 	return repo

--- a/client/python_interop/python_interop_test.go
+++ b/client/python_interop/python_interop_test.go
@@ -108,7 +108,7 @@ func generateRepoFS(c *C, dir string, files map[string][]byte, consistentSnapsho
 		c.Assert(ioutil.WriteFile(path, data, 0644), IsNil)
 		c.Assert(repo.AddTarget(file, nil), IsNil)
 	}
-	c.Assert(repo.Snapshot(tuf.CompressionTypeNone), IsNil)
+	c.Assert(repo.Snapshot(), IsNil)
 	c.Assert(repo.Timestamp(), IsNil)
 	c.Assert(repo.Commit(), IsNil)
 	return repo

--- a/client/testdata/go-tuf-transition-M3/generate.go
+++ b/client/testdata/go-tuf-transition-M3/generate.go
@@ -40,7 +40,7 @@ func newRepo(dir string) *tuf.Repo {
 }
 
 func commit(dir string, repo *tuf.Repo) {
-	assertNotNil(repo.SnapshotWithExpires(tuf.CompressionTypeNone, expirationDate))
+	assertNotNil(repo.SnapshotWithExpires(expirationDate))
 	assertNotNil(repo.TimestampWithExpires(expirationDate))
 	assertNotNil(repo.Commit())
 

--- a/client/testdata/go-tuf-transition-M4/generate.go
+++ b/client/testdata/go-tuf-transition-M4/generate.go
@@ -40,7 +40,7 @@ func newRepo(dir string) *tuf.Repo {
 }
 
 func commit(dir string, repo *tuf.Repo) {
-	assertNotNil(repo.SnapshotWithExpires(tuf.CompressionTypeNone, expirationDate))
+	assertNotNil(repo.SnapshotWithExpires(expirationDate))
 	assertNotNil(repo.TimestampWithExpires(expirationDate))
 	assertNotNil(repo.Commit())
 

--- a/client/testdata/go-tuf/generator/generator.go
+++ b/client/testdata/go-tuf/generator/generator.go
@@ -40,7 +40,7 @@ func newRepo(dir string) *tuf.Repo {
 }
 
 func commit(dir string, repo *tuf.Repo) {
-	assertNotNil(repo.SnapshotWithExpires(tuf.CompressionTypeNone, expirationDate))
+	assertNotNil(repo.SnapshotWithExpires(expirationDate))
 	assertNotNil(repo.TimestampWithExpires(expirationDate))
 	assertNotNil(repo.Commit())
 

--- a/cmd/tuf/snapshot.go
+++ b/cmd/tuf/snapshot.go
@@ -7,7 +7,7 @@ import (
 
 func init() {
 	register("snapshot", cmdSnapshot, `
-usage: tuf snapshot [--expires=<days>] [--compression=<format>]
+usage: tuf snapshot [--expires=<days>]
 
 Update the snapshot manifest.
 
@@ -17,13 +17,12 @@ Options:
 }
 
 func cmdSnapshot(args *docopt.Args, repo *tuf.Repo) error {
-	// TODO: parse --compression
 	if arg := args.String["--expires"]; arg != "" {
 		expires, err := parseExpires(arg)
 		if err != nil {
 			return err
 		}
-		return repo.SnapshotWithExpires(tuf.CompressionTypeNone, expires)
+		return repo.SnapshotWithExpires(expires)
 	}
-	return repo.Snapshot(tuf.CompressionTypeNone)
+	return repo.Snapshot()
 }

--- a/repo.go
+++ b/repo.go
@@ -16,13 +16,6 @@ import (
 	"github.com/theupdateframework/go-tuf/verify"
 )
 
-type CompressionType uint8
-
-const (
-	CompressionTypeNone CompressionType = iota
-	CompressionTypeGzip
-)
-
 // topLevelManifests determines the order signatures are verified when committing.
 var topLevelManifests = []string{
 	"root.json",
@@ -761,11 +754,11 @@ func (r *Repo) RemoveTargetsWithExpires(paths []string, expires time.Time) error
 	return r.setMeta("targets.json", t)
 }
 
-func (r *Repo) Snapshot(t CompressionType) error {
-	return r.SnapshotWithExpires(t, data.DefaultExpires("snapshot"))
+func (r *Repo) Snapshot() error {
+	return r.SnapshotWithExpires(data.DefaultExpires("snapshot"))
 }
 
-func (r *Repo) SnapshotWithExpires(t CompressionType, expires time.Time) error {
+func (r *Repo) SnapshotWithExpires(expires time.Time) error {
 	if !validExpires(expires) {
 		return ErrInvalidExpires{expires}
 	}
@@ -778,7 +771,7 @@ func (r *Repo) SnapshotWithExpires(t CompressionType, expires time.Time) error {
 	if err != nil {
 		return err
 	}
-	// TODO: generate compressed manifests
+
 	for _, name := range snapshotManifests {
 		if err := r.verifySignature(name, db); err != nil {
 			return err

--- a/repo_test.go
+++ b/repo_test.go
@@ -449,7 +449,7 @@ func (rs *RepoSuite) TestAddPrivateKey(c *C) {
 	addGeneratedPrivateKey(c, r, "snapshot")
 	addGeneratedPrivateKey(c, r, "timestamp")
 	c.Assert(r.AddTargets([]string{}, nil), IsNil)
-	c.Assert(r.Snapshot(CompressionTypeNone), IsNil)
+	c.Assert(r.Snapshot(), IsNil)
 	c.Assert(r.Timestamp(), IsNil)
 	c.Assert(r.Commit(), IsNil)
 
@@ -587,7 +587,7 @@ func (rs *RepoSuite) TestCommit(c *C) {
 
 	// commit without timestamp.json
 	genKey(c, r, "snapshot")
-	c.Assert(r.Snapshot(CompressionTypeNone), IsNil)
+	c.Assert(r.Snapshot(), IsNil)
 	c.Assert(r.Commit(), DeepEquals, ErrMissingMetadata{"timestamp.json"})
 
 	// commit with timestamp.json but no timestamp key
@@ -596,7 +596,7 @@ func (rs *RepoSuite) TestCommit(c *C) {
 
 	// commit success
 	genKey(c, r, "timestamp")
-	c.Assert(r.Snapshot(CompressionTypeNone), IsNil)
+	c.Assert(r.Snapshot(), IsNil)
 	c.Assert(r.Timestamp(), IsNil)
 	c.Assert(r.Commit(), IsNil)
 
@@ -606,15 +606,12 @@ func (rs *RepoSuite) TestCommit(c *C) {
 	c.Assert(r.Commit(), DeepEquals, errors.New("tuf: invalid root.json in snapshot.json: wrong length, expected 1740 got 2046"))
 
 	// commit with an invalid targets hash in snapshot.json
-	c.Assert(r.Snapshot(CompressionTypeNone), IsNil)
+	c.Assert(r.Snapshot(), IsNil)
 	c.Assert(r.AddTarget("bar.txt", nil), IsNil)
 	c.Assert(r.Commit(), DeepEquals, errors.New("tuf: invalid targets.json in snapshot.json: wrong length, expected 725 got 899"))
 
 	// commit with an invalid timestamp
-	c.Assert(r.Snapshot(CompressionTypeNone), IsNil)
-	// TODO: Change this test once Snapshot() supports compression and we
-	//       can guarantee the error will end in "wrong length" by
-	//       compressing a file and thus changing the size of snapshot.json
+	c.Assert(r.Snapshot(), IsNil)
 	err = r.Commit()
 	c.Assert(err, NotNil)
 	c.Assert(err.Error()[0:44], Equals, "tuf: invalid snapshot.json in timestamp.json")
@@ -629,7 +626,7 @@ func (rs *RepoSuite) TestCommit(c *C) {
 	c.Assert(role.KeyIDs, HasLen, 1)
 	c.Assert(role.Threshold, Equals, 1)
 	c.Assert(r.RevokeKey("timestamp", role.KeyIDs[0]), IsNil)
-	c.Assert(r.Snapshot(CompressionTypeNone), IsNil)
+	c.Assert(r.Snapshot(), IsNil)
 	c.Assert(r.Timestamp(), IsNil)
 	c.Assert(r.Commit(), DeepEquals, ErrNotEnoughKeys{"timestamp", 0, 1})
 }
@@ -646,7 +643,7 @@ func (rs *RepoSuite) TestCommitVersions(c *C) {
 	genKey(c, r, "timestamp")
 
 	c.Assert(r.AddTarget("foo.txt", nil), IsNil)
-	c.Assert(r.Snapshot(CompressionTypeNone), IsNil)
+	c.Assert(r.Snapshot(), IsNil)
 	c.Assert(r.Timestamp(), IsNil)
 	c.Assert(r.Commit(), IsNil)
 
@@ -667,8 +664,8 @@ func (rs *RepoSuite) TestCommitVersions(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(timestampVersion, Equals, 1)
 
-	// taking a snapshot should only incremept snapshot and timestamp.
-	c.Assert(r.Snapshot(CompressionTypeNone), IsNil)
+	// taking a snapshot should only increment snapshot and timestamp.
+	c.Assert(r.Snapshot(), IsNil)
 	c.Assert(r.Timestamp(), IsNil)
 	c.Assert(r.Commit(), IsNil)
 
@@ -692,7 +689,7 @@ func (rs *RepoSuite) TestCommitVersions(c *C) {
 	genKey(c, r, "targets")
 	genKey(c, r, "snapshot")
 	genKey(c, r, "timestamp")
-	c.Assert(r.Snapshot(CompressionTypeNone), IsNil)
+	c.Assert(r.Snapshot(), IsNil)
 	c.Assert(r.Timestamp(), IsNil)
 	c.Assert(r.Commit(), IsNil)
 
@@ -835,7 +832,7 @@ func (rs *RepoSuite) TestCommitFileSystem(c *C) {
 	}
 
 	// Snapshot() stages snapshot.json
-	c.Assert(r.Snapshot(CompressionTypeNone), IsNil)
+	c.Assert(r.Snapshot(), IsNil)
 	tmp.assertExists("staged/snapshot.json")
 	tmp.assertEmpty("repository")
 
@@ -858,7 +855,7 @@ func (rs *RepoSuite) TestCommitFileSystem(c *C) {
 	tmp.writeStagedTarget("path/to/bar.txt", "bar")
 	c.Assert(r.AddTarget("path/to/bar.txt", nil), IsNil)
 	tmp.assertExists("staged/targets.json")
-	c.Assert(r.Snapshot(CompressionTypeNone), IsNil)
+	c.Assert(r.Snapshot(), IsNil)
 	c.Assert(r.Timestamp(), IsNil)
 	c.Assert(r.Commit(), IsNil)
 	tmp.assertFileContent("repository/targets/foo.txt", "foo")
@@ -869,7 +866,7 @@ func (rs *RepoSuite) TestCommitFileSystem(c *C) {
 	// removing and committing a file removes it from repository/targets
 	c.Assert(r.RemoveTarget("foo.txt"), IsNil)
 	tmp.assertExists("staged/targets.json")
-	c.Assert(r.Snapshot(CompressionTypeNone), IsNil)
+	c.Assert(r.Snapshot(), IsNil)
 	c.Assert(r.Timestamp(), IsNil)
 	c.Assert(r.Commit(), IsNil)
 	tmp.assertNotExist("repository/targets/foo.txt")
@@ -895,7 +892,7 @@ func (rs *RepoSuite) TestCommitFileSystemWithNewRepositories(c *C) {
 
 	tmp.writeStagedTarget("foo.txt", "foo")
 	c.Assert(newRepo().AddTarget("foo.txt", nil), IsNil)
-	c.Assert(newRepo().Snapshot(CompressionTypeNone), IsNil)
+	c.Assert(newRepo().Snapshot(), IsNil)
 	c.Assert(newRepo().Timestamp(), IsNil)
 	c.Assert(newRepo().Commit(), IsNil)
 }
@@ -914,7 +911,7 @@ func (rs *RepoSuite) TestConsistentSnapshot(c *C) {
 	c.Assert(r.AddTarget("foo.txt", nil), IsNil)
 	tmp.writeStagedTarget("dir/bar.txt", "bar")
 	c.Assert(r.AddTarget("dir/bar.txt", nil), IsNil)
-	c.Assert(r.Snapshot(CompressionTypeNone), IsNil)
+	c.Assert(r.Snapshot(), IsNil)
 	c.Assert(r.Timestamp(), IsNil)
 	c.Assert(r.Commit(), IsNil)
 
@@ -949,7 +946,7 @@ func (rs *RepoSuite) TestConsistentSnapshot(c *C) {
 
 	// removing a file should remove the hashed files
 	c.Assert(r.RemoveTarget("foo.txt"), IsNil)
-	c.Assert(r.Snapshot(CompressionTypeNone), IsNil)
+	c.Assert(r.Snapshot(), IsNil)
 	c.Assert(r.Timestamp(), IsNil)
 	c.Assert(r.Commit(), IsNil)
 
@@ -998,7 +995,7 @@ func (rs *RepoSuite) TestExpiresAndVersion(c *C) {
 		genKeyErr,
 		r.AddTargetWithExpires("foo.txt", nil, past),
 		r.RemoveTargetWithExpires("foo.txt", past),
-		r.SnapshotWithExpires(CompressionTypeNone, past),
+		r.SnapshotWithExpires(past),
 		r.TimestampWithExpires(past),
 	} {
 		c.Assert(err, Equals, ErrInvalidExpires{past})
@@ -1010,7 +1007,7 @@ func (rs *RepoSuite) TestExpiresAndVersion(c *C) {
 	genKey(c, r, "timestamp")
 
 	c.Assert(r.AddTargets([]string{}, nil), IsNil)
-	c.Assert(r.Snapshot(CompressionTypeNone), IsNil)
+	c.Assert(r.Snapshot(), IsNil)
 	c.Assert(r.Timestamp(), IsNil)
 	c.Assert(r.Commit(), IsNil)
 
@@ -1021,7 +1018,7 @@ func (rs *RepoSuite) TestExpiresAndVersion(c *C) {
 	expires := time.Now().Add(24 * time.Hour)
 	_, err = r.GenKeyWithExpires("root", expires)
 	c.Assert(err, IsNil)
-	c.Assert(r.Snapshot(CompressionTypeNone), IsNil)
+	c.Assert(r.Snapshot(), IsNil)
 	c.Assert(r.Timestamp(), IsNil)
 	c.Assert(r.Commit(), IsNil)
 	root, err = r.root()
@@ -1036,7 +1033,7 @@ func (rs *RepoSuite) TestExpiresAndVersion(c *C) {
 	}
 	c.Assert(role.KeyIDs, HasLen, 2)
 	c.Assert(r.RevokeKeyWithExpires("root", role.KeyIDs[0], expires), IsNil)
-	c.Assert(r.Snapshot(CompressionTypeNone), IsNil)
+	c.Assert(r.Snapshot(), IsNil)
 	c.Assert(r.Timestamp(), IsNil)
 	c.Assert(r.Commit(), IsNil)
 	root, err = r.root()
@@ -1046,7 +1043,7 @@ func (rs *RepoSuite) TestExpiresAndVersion(c *C) {
 
 	expires = time.Now().Add(6 * time.Hour)
 	c.Assert(r.AddTargetWithExpires("foo.txt", nil, expires), IsNil)
-	c.Assert(r.Snapshot(CompressionTypeNone), IsNil)
+	c.Assert(r.Snapshot(), IsNil)
 	c.Assert(r.Timestamp(), IsNil)
 	c.Assert(r.Commit(), IsNil)
 	targets, err := r.targets()
@@ -1056,7 +1053,7 @@ func (rs *RepoSuite) TestExpiresAndVersion(c *C) {
 
 	expires = time.Now().Add(2 * time.Hour)
 	c.Assert(r.RemoveTargetWithExpires("foo.txt", expires), IsNil)
-	c.Assert(r.Snapshot(CompressionTypeNone), IsNil)
+	c.Assert(r.Snapshot(), IsNil)
 	c.Assert(r.Timestamp(), IsNil)
 	c.Assert(r.Commit(), IsNil)
 	targets, err = r.targets()
@@ -1065,7 +1062,7 @@ func (rs *RepoSuite) TestExpiresAndVersion(c *C) {
 	c.Assert(targets.Version, Equals, 3)
 
 	expires = time.Now().Add(time.Hour)
-	c.Assert(r.SnapshotWithExpires(CompressionTypeNone, expires), IsNil)
+	c.Assert(r.SnapshotWithExpires(expires), IsNil)
 	c.Assert(r.Timestamp(), IsNil)
 	c.Assert(r.Commit(), IsNil)
 	snapshot, err := r.snapshot()
@@ -1078,7 +1075,7 @@ func (rs *RepoSuite) TestExpiresAndVersion(c *C) {
 	c.Assert(snapshot.Meta["root.json"].Version, Equals, root.Version)
 	c.Assert(snapshot.Meta["targets.json"].Version, Equals, targets.Version)
 
-	c.Assert(r.Snapshot(CompressionTypeNone), IsNil)
+	c.Assert(r.Snapshot(), IsNil)
 	c.Assert(r.Timestamp(), IsNil)
 	c.Assert(r.Commit(), IsNil)
 	snapshot, err = r.snapshot()
@@ -1120,7 +1117,7 @@ func (rs *RepoSuite) TestHashAlgorithm(c *C) {
 		genKey(c, r, "targets")
 		genKey(c, r, "snapshot")
 		c.Assert(r.AddTarget("foo.txt", nil), IsNil)
-		c.Assert(r.Snapshot(CompressionTypeNone), IsNil)
+		c.Assert(r.Snapshot(), IsNil)
 		c.Assert(r.Timestamp(), IsNil)
 
 		// check metadata has correct hash functions
@@ -1238,7 +1235,7 @@ func (rs *RepoSuite) TestManageMultipleTargets(c *C) {
 	tmp.writeStagedTarget("foo.txt", "foo")
 	tmp.writeStagedTarget("bar.txt", "bar")
 	c.Assert(r.AddTargets([]string{"foo.txt", "bar.txt"}, nil), IsNil)
-	c.Assert(r.Snapshot(CompressionTypeNone), IsNil)
+	c.Assert(r.Snapshot(), IsNil)
 	c.Assert(r.Timestamp(), IsNil)
 	c.Assert(r.Commit(), IsNil)
 	assertRepoTargets("foo.txt", "bar.txt")
@@ -1253,7 +1250,7 @@ func (rs *RepoSuite) TestManageMultipleTargets(c *C) {
 		tmp.writeStagedTarget(files[i], "data")
 	}
 	c.Assert(r.AddTargets(nil, nil), IsNil)
-	c.Assert(r.Snapshot(CompressionTypeNone), IsNil)
+	c.Assert(r.Snapshot(), IsNil)
 	c.Assert(r.Timestamp(), IsNil)
 	c.Assert(r.Commit(), IsNil)
 	tmp.assertExists("repository/targets/foo.txt")
@@ -1267,7 +1264,7 @@ func (rs *RepoSuite) TestManageMultipleTargets(c *C) {
 
 	// removing all targets removes them from the repository and targets.json
 	c.Assert(r.RemoveTargets(nil), IsNil)
-	c.Assert(r.Snapshot(CompressionTypeNone), IsNil)
+	c.Assert(r.Snapshot(), IsNil)
 	c.Assert(r.Timestamp(), IsNil)
 	c.Assert(r.Commit(), IsNil)
 	tmp.assertEmpty("repository/targets")
@@ -1337,7 +1334,7 @@ func (rs *RepoSuite) TestUnknownKeyIDs(c *C) {
 
 	// commit the metadata to the store.
 	c.Assert(r.AddTargets([]string{}, nil), IsNil)
-	c.Assert(r.Snapshot(CompressionTypeNone), IsNil)
+	c.Assert(r.Snapshot(), IsNil)
 	c.Assert(r.Timestamp(), IsNil)
 	c.Assert(r.Commit(), IsNil)
 
@@ -1364,7 +1361,7 @@ func (rs *RepoSuite) TestUnknownKeyIDs(c *C) {
 	root, err = r.root()
 
 	genKey(c, r, "timestamp")
-	c.Assert(r.Snapshot(CompressionTypeNone), IsNil)
+	c.Assert(r.Snapshot(), IsNil)
 	c.Assert(r.Timestamp(), IsNil)
 	c.Assert(r.Commit(), IsNil)
 
@@ -1398,7 +1395,7 @@ func (rs *RepoSuite) TestThreshold(c *C) {
 
 	// commit the metadata to the store.
 	c.Assert(r.AddTargets([]string{}, nil), IsNil)
-	c.Assert(r.Snapshot(CompressionTypeNone), IsNil)
+	c.Assert(r.Snapshot(), IsNil)
 	c.Assert(r.Timestamp(), IsNil)
 	c.Assert(r.Commit(), IsNil)
 
@@ -1412,7 +1409,7 @@ func (rs *RepoSuite) TestThreshold(c *C) {
 	// Add a second root key and try again
 	genKey(c, r, "root")
 	c.Assert(r.Sign("root.json"), IsNil)
-	c.Assert(r.Snapshot(CompressionTypeNone), IsNil)
+	c.Assert(r.Snapshot(), IsNil)
 	c.Assert(r.Timestamp(), IsNil)
 	c.Assert(r.Commit(), IsNil)
 
@@ -1481,7 +1478,7 @@ func (rs *RepoSuite) TestAddOrUpdateSignatures(c *C) {
 	}
 
 	// snapshot and timestamp
-	c.Assert(r.Snapshot(CompressionTypeNone), IsNil)
+	c.Assert(r.Snapshot(), IsNil)
 	snapshotMeta, err := r.SignedMeta("snapshot.json")
 	c.Assert(err, IsNil)
 	snapshotSig, err := snapshotKey.Signer().Sign(rand.Reader, snapshotMeta.Signed, crypto.Hash(0))


### PR DESCRIPTION
The following PR removes the `--compression` option when creating a snapshot. It also updates the related tests and the README.md file. 

This change is a result of [TAP10](https://github.com/theupdateframework/taps/blob/master/tap10.md).

Closes issue #7 as it's no longer applicable.