### PR TITLE
Update CLI descriptions and their reference in the README.md file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+cmd/tuf/tuf
+cmd/tuf-client/tuf-client

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ a framework for securing software update systems.
 
 A TUF repository has the following directory layout:
 
-```
+```bash
 .
 ├── keys
 ├── repository
@@ -32,7 +32,7 @@ The directories contain the following files:
 
 ### Install
 
-```
+```bash
 go get github.com/theupdateframework/go-tuf/cmd/tuf
 ```
 
@@ -52,12 +52,15 @@ initialized to do so when generating keys.
 Prompts the user for an encryption passphrase (unless the
 `--insecure-plaintext` flag is set), then generates a new signing key and
 writes it to the relevant key file in the `keys` directory. It also stages
-the addition of the new key to the `root` manifest.
+the addition of the new key to the `root` manifest. Alternatively, passphrases
+can be set via environment variables in the form of `TUF_{{ROLE}}_PASSPHRASE`
 
-#### `tuf set-threshold <role> <threshold>`
+#### `tuf revoke-key [--expires=<days>] <role> <id>`
 
-Sets the `role` threshold, the required number of keys for signing, to
-`threshold`.
+Revoke a signing key
+
+The key will be removed from the root manifest, but the key will remain in the
+"keys" directory if present.
 
 #### `tuf add [<path>...]`
 
@@ -82,7 +85,7 @@ the snapshot manifest will expire.
 Stages an appropriate `timestamp` manifest. If a `snapshot` manifest is staged,
 it must be fully signed.
 
-#### `tuf sign ROLE`
+#### `tuf sign <manifest>`
 
 Signs the given role's staged manifest with all keys present in the `keys`
 directory for that role.
@@ -96,6 +99,8 @@ manifest.
 
 #### `tuf regenerate [--consistent-snapshot=false]`
 
+Note: Not supported yet
+
 Recreates the `targets` manifest based on the files in `repository/targets`.
 
 #### `tuf clean`
@@ -106,6 +111,16 @@ Removes all staged manifests and targets.
 
 Outputs a JSON serialized array of root keys to STDOUT. The resulting JSON
 should be distributed to clients for performing initial updates.
+
+#### `tuf set-threshold <role> <threshold>`
+
+Sets the `role` threshold, the required number of keys for signing, to
+`threshold`.
+
+#### Usage of environment variables
+
+The `tuf` CLI supports receiving passphrases via environment variables in
+the form of `TUF_{{ROLE}}_PASSPHRASE`
 
 For a list of supported commands, run `tuf help` from the command line.
 
@@ -126,7 +141,7 @@ Some key IDs are truncated for illustrative purposes.
 
 Generate a root key on the root box:
 
-```
+```bash
 $ tuf gen-key root
 Enter root keys passphrase:
 Repeat root keys passphrase:
@@ -145,7 +160,7 @@ $ tree .
 Copy `staged/root.json` from the root box to the repo box and generate targets,
 snapshot and timestamp keys:
 
-```
+```bash
 $ tree .
 .
 ├── keys
@@ -183,7 +198,7 @@ $ tree .
 
 Copy `staged/root.json` from the repo box back to the root box and sign it:
 
-```
+```bash
 $ tree .
 .
 ├── keys
@@ -205,7 +220,7 @@ committed alongside other manifests.
 Assuming a staged, signed `root` manifest and the file to add exists at
 `staged/targets/foo/bar/baz.txt`:
 
-```
+```bash
 $ tree .
 .
 ├── keys
@@ -285,7 +300,7 @@ $ tree .
 
 Assuming the file to remove is at `repository/targets/foo/bar/baz.txt`:
 
-```
+```bash
 $ tree .
 .
 ├── keys
@@ -366,9 +381,9 @@ $ tree .
 └── staged
 ```
 
-#### Regenerate manifests based on targets tree
+#### Regenerate manifests based on targets tree (Note: Not supported yet)
 
-```
+```bash
 $ tree .
 .
 ├── keys
@@ -455,7 +470,7 @@ $ tree .
 
 #### Update timestamp.json
 
-```
+```bash
 $ tree .
 .
 ├── keys

--- a/cmd/tuf/add.go
+++ b/cmd/tuf/add.go
@@ -13,6 +13,9 @@ usage: tuf add [--expires=<days>] [--custom=<data>] [<path>...]
 
 Add target file(s).
 
+Alternatively, passphrases can be set via environment variables in the
+form of TUF_{{ROLE}}_PASSPHRASE
+
 Options:
   --expires=<days>   Set the targets manifest to expire <days> days from now.
   --custom=<data>    Set custom JSON data for the target(s).

--- a/cmd/tuf/clean.go
+++ b/cmd/tuf/clean.go
@@ -13,7 +13,7 @@ func init() {
 usage: tuf clean
 
 Remove all staged manifests.
-  `)
+`)
 }
 
 func cmdClean(args *docopt.Args, repo *tuf.Repo) error {

--- a/cmd/tuf/gen_key.go
+++ b/cmd/tuf/gen_key.go
@@ -18,6 +18,9 @@ The key will be serialized to JSON and written to the "keys" directory with
 filename pattern "ROLE-KEYID.json". The root manifest will also be staged
 with the addition of the key's ID to the role's list of key IDs.
 
+Alternatively, passphrases can be set via environment variables in the
+form of TUF_{{ROLE}}_PASSPHRASE
+
 Options:
   --expires=<days>   Set the root manifest to expire <days> days from now.
 `)

--- a/cmd/tuf/main.go
+++ b/cmd/tuf/main.go
@@ -28,18 +28,19 @@ Options:
   --insecure-plaintext  Don't encrypt signing keys
 
 Commands:
-  help         Show usage for a specific command
-  gen-key      Generate a new signing key for a specific manifest
-  revoke-key   Revoke a signing key
-  add          Add target file(s)
-  remove       Remove a target file
-  snapshot     Update the snapshot manifest
-  timestamp    Update the timestamp manifest
-  sign         Sign a manifest
-  commit       Commit staged files to the repository
-  regenerate   Recreate the targets manifest
-  clean        Remove all staged manifests
-  root-keys    Output a JSON serialized array of root keys to STDOUT
+  help          Show usage for a specific command
+  init          Initialize a new repository
+  gen-key       Generate a new signing key for a specific manifest
+  revoke-key    Revoke a signing key
+  add           Add target file(s)
+  remove        Remove a target file
+  snapshot      Update the snapshot manifest
+  timestamp     Update the timestamp manifest
+  sign          Sign a role's manifest
+  commit        Commit staged files to the repository
+  regenerate    Recreate the targets manifest [Not supported yet]
+  clean         Remove all staged manifests
+  root-keys     Output a JSON serialized array of root keys to STDOUT
   set-threshold Sets the threshold for a role
 
 See "tuf help <command>" for more information on a specific command

--- a/cmd/tuf/regenerate.go
+++ b/cmd/tuf/regenerate.go
@@ -11,12 +11,15 @@ func init() {
 	register("regenerate", cmdRegenerate, `
 usage: tuf regenerate [--consistent-snapshot=false]
 
-Recreate the targets manifest.
-  `)
+Recreate the targets manifest. Important: Not supported yet
+
+Alternatively, passphrases can be set via environment variables in the
+form of TUF_{{ROLE}}_PASSPHRASE
+`)
 }
 
 func cmdRegenerate(args *docopt.Args, repo *tuf.Repo) error {
 	// TODO: implement this
-	log.Println("not implemented")
+	log.Println("Not supported yet")
 	return nil
 }

--- a/cmd/tuf/remove.go
+++ b/cmd/tuf/remove.go
@@ -13,6 +13,9 @@ usage: tuf remove [--expires=<days>] [--all] [<path>...]
 
 Remove target file(s).
 
+Alternatively, passphrases can be set via environment variables in the
+form of TUF_{{ROLE}}_PASSPHRASE
+
 Options:
   --all              Remove all target files.
   --expires=<days>   Set the targets manifest to expire <days> days from now.

--- a/cmd/tuf/sign.go
+++ b/cmd/tuf/sign.go
@@ -9,7 +9,10 @@ func init() {
 	register("sign", cmdSign, `
 usage: tuf sign <manifest>
 
-Sign a manifest.
+Sign a role's manifest.
+
+Signs the given role's staged manifest with all keys present in the 'keys'
+directory for that role.
 `)
 }
 

--- a/cmd/tuf/snapshot.go
+++ b/cmd/tuf/snapshot.go
@@ -11,6 +11,9 @@ usage: tuf snapshot [--expires=<days>]
 
 Update the snapshot manifest.
 
+Alternatively, passphrases can be set via environment variables in the
+form of TUF_{{ROLE}}_PASSPHRASE
+
 Options:
   --expires=<days>   Set the snapshot manifest to expire <days> days from now.
 `)

--- a/cmd/tuf/timestamp.go
+++ b/cmd/tuf/timestamp.go
@@ -11,6 +11,9 @@ usage: tuf timestamp [--expires=<days>]
 
 Update the timestamp manifest.
 
+Alternatively, passphrases can be set via environment variables in the
+form of TUF_{{ROLE}}_PASSPHRASE
+
 Options:
   --expires=<days>   Set the timestamp manifest to expire <days> days from now.
 `)

--- a/repo.go
+++ b/repo.go
@@ -946,7 +946,7 @@ func (r *Repo) Commit() error {
 		return err
 	}
 
-	// We can start incrementing versin numbers again now that we've
+	// We can start incrementing version numbers again now that we've
 	// successfully committed the metadata to the local store.
 	r.versionUpdated = make(map[string]struct{})
 


### PR DESCRIPTION
The following PR updates the descriptions we provide for the CLI options along with some additional housekeeping.

Details:
- Added `.gitignore` file for ignoring `tuf` and `tuf-client` executables
- Added entry for `init` in the `tuf help` message
- Added documentation about the use of environment variables for passing each role's passphrases -`TUF_{{ROLE}}_PASSPHRASE` closing #73 
- Added documentation for `revoke-key` in README.md - closing #85 
- Added a "not-supported-yet" status for the `regenerate` command as it's still not implemented
- Updated the info for the `sign` command in the README.md file - it expects a role metadata filename (i.e. targets.json) instead of just the name of the role