### PR TITLE
Rename manifest to metadata for consistency with the TUF specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ A TUF repository has the following directory layout:
 The directories contain the following files:
 
 - `keys/` - signing keys (optionally encrypted) with filename pattern `ROLE.json`
-- `repository/` - signed manifests
+- `repository/` - signed metadata files
 - `repository/targets/` - hashed target files
-- `staged/` - either signed, unsigned or partially signed manifests
+- `staged/` - either signed, unsigned or partially signed metadata files
 - `staged/targets/` - unhashed target files
 
 ## CLI
@@ -52,42 +52,42 @@ initialized to do so when generating keys.
 Prompts the user for an encryption passphrase (unless the
 `--insecure-plaintext` flag is set), then generates a new signing key and
 writes it to the relevant key file in the `keys` directory. It also stages
-the addition of the new key to the `root` manifest. Alternatively, passphrases
+the addition of the new key to the `root` metadata file. Alternatively, passphrases
 can be set via environment variables in the form of `TUF_{{ROLE}}_PASSPHRASE`
 
 #### `tuf revoke-key [--expires=<days>] <role> <id>`
 
 Revoke a signing key
 
-The key will be removed from the root manifest, but the key will remain in the
+The key will be removed from the root metadata file, but the key will remain in the
 "keys" directory if present.
 
 #### `tuf add [<path>...]`
 
 Hashes files in the `staged/targets` directory at the given path(s), then
-updates and stages the `targets` manifest. Specifying no paths hashes all
+updates and stages the `targets` metadata file. Specifying no paths hashes all
 files in the `staged/targets` directory.
 
 #### `tuf remove [<path>...]`
 
-Stages the removal of files with the given path(s) from the `targets` manifest
+Stages the removal of files with the given path(s) from the `targets` metadata file
 (they get removed from the filesystem when the change is committed). Specifying
-no paths removes all files from the `targets` manifest.
+no paths removes all files from the `targets` metadata file.
 
 #### `tuf snapshot [--expires=<days>]`
 
-Expects a staged, fully signed `targets` manifest and stages an appropriate
-`snapshot` manifest. Optionally one can set number of days after which
-the snapshot manifest will expire.
+Expects a staged, fully signed `targets` metadata file and stages an appropriate
+`snapshot` metadata file. Optionally one can set number of days after which
+the `snapshot` metadata will expire.
 
 #### `tuf timestamp`
 
-Stages an appropriate `timestamp` manifest. If a `snapshot` manifest is staged,
+Stages an appropriate `timestamp` metadata file. If a `snapshot` metadata file is staged,
 it must be fully signed.
 
-#### `tuf sign <manifest>`
+#### `tuf sign <metadata>`
 
-Signs the given role's staged manifest with all keys present in the `keys`
+Signs the given role's staged metadata file with all keys present in the `keys`
 directory for that role.
 
 #### `tuf commit`
@@ -95,17 +95,17 @@ directory for that role.
 Verifies that all staged changes contain the correct information and are signed
 to the correct threshold, then moves the staged files into the `repository`
 directory. It also removes any target files which are not in the `targets`
-manifest.
+metadata file.
 
 #### `tuf regenerate [--consistent-snapshot=false]`
 
 Note: Not supported yet
 
-Recreates the `targets` manifest based on the files in `repository/targets`.
+Recreates the `targets` metadata file based on the files in `repository/targets`.
 
 #### `tuf clean`
 
-Removes all staged manifests and targets.
+Removes all staged metadata files and targets.
 
 #### `tuf root-keys`
 
@@ -137,7 +137,7 @@ staged changes and signing on each machine in turn before finally committing.
 
 Some key IDs are truncated for illustrative purposes.
 
-#### Create signed root manifest
+#### Create signed root metadata file
 
 Generate a root key on the root box:
 
@@ -213,11 +213,11 @@ Enter root keys passphrase:
 ```
 
 The staged `root.json` can now be copied back to the repo box ready to be
-committed alongside other manifests.
+committed alongside other metadata files.
 
 #### Add a target file
 
-Assuming a staged, signed `root` manifest and the file to add exists at
+Assuming a staged, signed `root` metadata file and the file to add exists at
 `staged/targets/foo/bar/baz.txt`:
 
 ```bash
@@ -381,7 +381,7 @@ $ tree .
 └── staged
 ```
 
-#### Regenerate manifests based on targets tree (Note: Not supported yet)
+#### Regenerate metadata files based on targets tree (Note: Not supported yet)
 
 ```bash
 $ tree .

--- a/cmd/tuf/add.go
+++ b/cmd/tuf/add.go
@@ -17,7 +17,7 @@ Alternatively, passphrases can be set via environment variables in the
 form of TUF_{{ROLE}}_PASSPHRASE
 
 Options:
-  --expires=<days>   Set the targets manifest to expire <days> days from now.
+  --expires=<days>   Set the targets metadata file to expire <days> days from now.
   --custom=<data>    Set custom JSON data for the target(s).
 `)
 }

--- a/cmd/tuf/clean.go
+++ b/cmd/tuf/clean.go
@@ -12,7 +12,7 @@ func init() {
 	register("clean", cmdClean, `
 usage: tuf clean
 
-Remove all staged manifests.
+Remove all staged metadata files.
 `)
 }
 

--- a/cmd/tuf/gen_key.go
+++ b/cmd/tuf/gen_key.go
@@ -15,14 +15,14 @@ usage: tuf gen-key [--expires=<days>] <role>
 Generate a new signing key for the given role.
 
 The key will be serialized to JSON and written to the "keys" directory with
-filename pattern "ROLE-KEYID.json". The root manifest will also be staged
+filename pattern "ROLE-KEYID.json". The root metadata file will also be staged
 with the addition of the key's ID to the role's list of key IDs.
 
 Alternatively, passphrases can be set via environment variables in the
 form of TUF_{{ROLE}}_PASSPHRASE
 
 Options:
-  --expires=<days>   Set the root manifest to expire <days> days from now.
+  --expires=<days>   Set the root metadata file to expire <days> days from now.
 `)
 }
 

--- a/cmd/tuf/main.go
+++ b/cmd/tuf/main.go
@@ -30,16 +30,16 @@ Options:
 Commands:
   help          Show usage for a specific command
   init          Initialize a new repository
-  gen-key       Generate a new signing key for a specific manifest
+  gen-key       Generate a new signing key for a specific metadata file
   revoke-key    Revoke a signing key
   add           Add target file(s)
   remove        Remove a target file
-  snapshot      Update the snapshot manifest
-  timestamp     Update the timestamp manifest
-  sign          Sign a role's manifest
+  snapshot      Update the snapshot metadata file
+  timestamp     Update the timestamp metadata file
+  sign          Sign a role's metadata file
   commit        Commit staged files to the repository
-  regenerate    Recreate the targets manifest [Not supported yet]
-  clean         Remove all staged manifests
+  regenerate    Recreate the targets metadata file [Not supported yet]
+  clean         Remove all staged metadata files
   root-keys     Output a JSON serialized array of root keys to STDOUT
   set-threshold Sets the threshold for a role
 

--- a/cmd/tuf/regenerate.go
+++ b/cmd/tuf/regenerate.go
@@ -11,7 +11,7 @@ func init() {
 	register("regenerate", cmdRegenerate, `
 usage: tuf regenerate [--consistent-snapshot=false]
 
-Recreate the targets manifest. Important: Not supported yet
+Recreate the targets metadata file. Important: Not supported yet
 
 Alternatively, passphrases can be set via environment variables in the
 form of TUF_{{ROLE}}_PASSPHRASE

--- a/cmd/tuf/remove.go
+++ b/cmd/tuf/remove.go
@@ -18,7 +18,7 @@ form of TUF_{{ROLE}}_PASSPHRASE
 
 Options:
   --all              Remove all target files.
-  --expires=<days>   Set the targets manifest to expire <days> days from now.
+  --expires=<days>   Set the targets metadata file to expire <days> days from now.
 `)
 }
 

--- a/cmd/tuf/revoke_key.go
+++ b/cmd/tuf/revoke_key.go
@@ -11,11 +11,11 @@ usage: tuf revoke-key [--expires=<days>] <role> <id>
 
 Revoke a signing key
 
-The key will be removed from the root manifest, but the key will remain in the
+The key will be removed from the root metadata file, but the key will remain in the
 "keys" directory if present.
 
 Options:
-  --expires=<days>   Set the root manifest to expire <days> days from now.
+  --expires=<days>   Set the root metadata file to expire <days> days from now.
 `)
 }
 

--- a/cmd/tuf/sign.go
+++ b/cmd/tuf/sign.go
@@ -7,15 +7,15 @@ import (
 
 func init() {
 	register("sign", cmdSign, `
-usage: tuf sign <manifest>
+usage: tuf sign <metadata>
 
-Sign a role's manifest.
+Sign a role's metadata file.
 
-Signs the given role's staged manifest with all keys present in the 'keys'
+Signs the given role's staged metadata file with all keys present in the 'keys'
 directory for that role.
 `)
 }
 
 func cmdSign(args *docopt.Args, repo *tuf.Repo) error {
-	return repo.Sign(args.String["<manifest>"])
+	return repo.Sign(args.String["<metadata>"])
 }

--- a/cmd/tuf/snapshot.go
+++ b/cmd/tuf/snapshot.go
@@ -9,13 +9,13 @@ func init() {
 	register("snapshot", cmdSnapshot, `
 usage: tuf snapshot [--expires=<days>]
 
-Update the snapshot manifest.
+Update the snapshot metadata file.
 
 Alternatively, passphrases can be set via environment variables in the
 form of TUF_{{ROLE}}_PASSPHRASE
 
 Options:
-  --expires=<days>   Set the snapshot manifest to expire <days> days from now.
+  --expires=<days>   Set the snapshot metadata file to expire <days> days from now.
 `)
 }
 

--- a/cmd/tuf/timestamp.go
+++ b/cmd/tuf/timestamp.go
@@ -9,13 +9,13 @@ func init() {
 	register("timestamp", cmdTimestamp, `
 usage: tuf timestamp [--expires=<days>]
 
-Update the timestamp manifest.
+Update the timestamp metadata file.
 
 Alternatively, passphrases can be set via environment variables in the
 form of TUF_{{ROLE}}_PASSPHRASE
 
 Options:
-  --expires=<days>   Set the timestamp manifest to expire <days> days from now.
+  --expires=<days>   Set the timestamp metadata file to expire <days> days from now.
 `)
 }
 

--- a/local_store.go
+++ b/local_store.go
@@ -131,7 +131,7 @@ func (f *fileSystemStore) GetMeta() (map[string]json.RawMessage, error) {
 		_, err := os.Stat(path)
 		return os.IsNotExist(err)
 	}
-	for _, name := range topLevelManifests {
+	for _, name := range topLevelMetadata {
 		path := filepath.Join(f.stagedDir(), name)
 		if notExists(path) {
 			path = filepath.Join(f.repoDir(), name)


### PR DESCRIPTION
The following PR renames the use of `manifest` to `metadata` so the implementation is consistent with what is used within the TUF specification.

Signed-off-by: Radoslav Dimitrov <dimitrovr@vmware.com>