### PR TITLE
make the updateRoots public

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -151,7 +151,7 @@ func (c *Client) Init(rootKeys []*data.Key, threshold int) error {
 //
 // https://theupdateframework.github.io/specification/v1.0.19/index.html#load-trusted-root
 func (c *Client) Update() (data.TargetFiles, error) {
-	if err := c.updateRoots(); err != nil {
+	if err := c.UpdateRoots(); err != nil {
 		if _, ok := err.(verify.ErrExpired); ok {
 			// For backward compatibility, we wrap the ErrExpired inside
 			// ErrDecodeFailed.
@@ -216,7 +216,7 @@ func (c *Client) Update() (data.TargetFiles, error) {
 	return updatedTargets, nil
 }
 
-func (c *Client) updateRoots() error {
+func (c *Client) UpdateRoots() error {
 	// https://theupdateframework.github.io/specification/v1.0.19/index.html#load-trusted-root
 	// 5.2 Load the trusted root metadata file. We assume that a good,
 	// trusted copy of this file was shipped with the package manager

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -515,7 +515,7 @@ func (s *ClientSuite) TestFastForwardAttackRecovery(c *C) {
 	}
 	for _, test := range tests {
 		tufClient, closer := initRootTest(c, test.fixturePath)
-		c.Assert(tufClient.updateRoots(), IsNil)
+		c.Assert(tufClient.UpdateRoots(), IsNil)
 		m, err := tufClient.local.GetMeta()
 		c.Assert(err, IsNil)
 		for md, deleted := range test.expectMetaDeleted {


### PR DESCRIPTION
For partial verification, we should be able to update the root without needing the update of the non-root metadata. 
This is because in many implementations of the partial verification, there is no timestamp or snapshot so a general update will fail.