### PR TITLE
Improve the CLI experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,11 @@ Expects a staged, fully signed `targets` metadata file and stages an appropriate
 `snapshot` metadata file. Optionally one can set number of days after which
 the `snapshot` metadata will expire.
 
-#### `tuf timestamp`
+#### `tuf timestamp [--expires=<days>]`
 
 Stages an appropriate `timestamp` metadata file. If a `snapshot` metadata file is staged,
-it must be fully signed.
+it must be fully signed. Optionally one can set number of days after which
+the timestamp metadata will expire.
 
 #### `tuf sign <metadata>`
 

--- a/README.md
+++ b/README.md
@@ -115,8 +115,12 @@ should be distributed to clients for performing initial updates.
 
 #### `tuf set-threshold <role> <threshold>`
 
-Sets the `role` threshold, the required number of keys for signing, to
+Sets the `role` threshold (required number of keys for signing) to
 `threshold`.
+
+#### `tuf get-threshold <role>`
+
+Outputs the `role` threshold (required number of keys for signing).
 
 #### Usage of environment variables
 

--- a/README.md
+++ b/README.md
@@ -115,12 +115,12 @@ should be distributed to clients for performing initial updates.
 
 #### `tuf set-threshold <role> <threshold>`
 
-Sets the `role` threshold (required number of keys for signing) to
+Sets `role`'s threshold (required number of keys for signing) to
 `threshold`.
 
 #### `tuf get-threshold <role>`
 
-Outputs the `role` threshold (required number of keys for signing).
+Outputs `role`'s threshold (required number of keys for signing).
 
 #### Usage of environment variables
 

--- a/cmd/tuf/get_threshold.go
+++ b/cmd/tuf/get_threshold.go
@@ -23,6 +23,6 @@ func cmdGetThreshold(args *docopt.Args, repo *tuf.Repo) error {
 		return err
 	}
 
-	fmt.Println("Got", role, "threshold", threshold)
+	fmt.Println("The threshold for", role, "role is", threshold)
 	return nil
 }

--- a/cmd/tuf/main.go
+++ b/cmd/tuf/main.go
@@ -42,6 +42,7 @@ Commands:
   clean         Remove all staged metadata files
   root-keys     Output a JSON serialized array of root keys to STDOUT
   set-threshold Sets the threshold for a role
+  get-threshold Outputs the threshold for a role
 
 See "tuf help <command>" for more information on a specific command
 `

--- a/cmd/tuf/root_keys.go
+++ b/cmd/tuf/root_keys.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"encoding/json"
-	"os"
+	"fmt"
 
 	"github.com/flynn/go-docopt"
 	"github.com/theupdateframework/go-tuf"
@@ -23,5 +23,9 @@ func cmdRootKeys(args *docopt.Args, repo *tuf.Repo) error {
 	if err != nil {
 		return err
 	}
-	return json.NewEncoder(os.Stdout).Encode(keys)
+	data, err := json.Marshal(keys)
+	if err == nil {
+		fmt.Printf("The resulting JSON should be distributed to clients for performing initial updates:\n\n%s\n", string(data))
+	}
+	return err
 }

--- a/cmd/tuf/root_keys.go
+++ b/cmd/tuf/root_keys.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/flynn/go-docopt"
 	"github.com/theupdateframework/go-tuf"
@@ -10,11 +11,14 @@ import (
 
 func init() {
 	register("root-keys", cmdRootKeys, `
-usage: tuf root-keys
+usage: tuf root-keys [-q|--quiet]
 
 Outputs a JSON serialized array of root keys to STDOUT.
 
 The resulting JSON should be distributed to clients for performing initial updates.
+
+Options:
+  [-q|--quiet] Run command in quiet/less verbose mode
 `)
 }
 
@@ -25,7 +29,10 @@ func cmdRootKeys(args *docopt.Args, repo *tuf.Repo) error {
 	}
 	data, err := json.Marshal(keys)
 	if err == nil {
-		fmt.Printf("The resulting JSON should be distributed to clients for performing initial updates:\n\n%s\n", string(data))
+		if !args.Bool["-q"] && !args.Bool["--quiet"] {
+			fmt.Fprintf(os.Stderr, "The resulting JSON should be distributed to clients for performing initial updates:\n\n")
+		}
+		fmt.Fprintln(os.Stdout, string(data))
 	}
 	return err
 }

--- a/cmd/tuf/root_keys.go
+++ b/cmd/tuf/root_keys.go
@@ -11,14 +11,11 @@ import (
 
 func init() {
 	register("root-keys", cmdRootKeys, `
-usage: tuf root-keys [-q|--quiet]
+usage: tuf root-keys
 
 Outputs a JSON serialized array of root keys to STDOUT.
 
 The resulting JSON should be distributed to clients for performing initial updates.
-
-Options:
-  [-q|--quiet] Run command in quiet/less verbose mode
 `)
 }
 
@@ -29,9 +26,7 @@ func cmdRootKeys(args *docopt.Args, repo *tuf.Repo) error {
 	}
 	data, err := json.Marshal(keys)
 	if err == nil {
-		if !args.Bool["-q"] && !args.Bool["--quiet"] {
-			fmt.Fprintf(os.Stderr, "The resulting JSON should be distributed to clients for performing initial updates:\n\n")
-		}
+		fmt.Fprintf(os.Stderr, "The resulting JSON should be distributed to clients for performing initial updates:\n\n")
 		fmt.Fprintln(os.Stdout, string(data))
 	}
 	return err

--- a/cmd/tuf/set_threshold.go
+++ b/cmd/tuf/set_threshold.go
@@ -28,6 +28,6 @@ func cmdSetThreshold(args *docopt.Args, repo *tuf.Repo) error {
 		return err
 	}
 
-	fmt.Println("The treshold for", role, "role is", threshold)
+	fmt.Println("The threshold for", role, "role is now", threshold)
 	return nil
 }

--- a/cmd/tuf/set_threshold.go
+++ b/cmd/tuf/set_threshold.go
@@ -28,6 +28,6 @@ func cmdSetThreshold(args *docopt.Args, repo *tuf.Repo) error {
 		return err
 	}
 
-	fmt.Println("Set ", role, "threshold to", threshold)
+	fmt.Println("The treshold for", role, "role is", threshold)
 	return nil
 }

--- a/repo.go
+++ b/repo.go
@@ -476,7 +476,11 @@ func (r *Repo) RevokeKeyWithExpires(keyRole, id string, expires time.Time) error
 		r.versionUpdated["root.json"] = struct{}{}
 	}
 
-	return r.setMeta("root.json", root)
+	err = r.setMeta("root.json", root)
+	if err == nil {
+		fmt.Println("Revoked", keyRole, "key with ID", id)
+	}
+	return err
 }
 
 func (r *Repo) jsonMarshal(v interface{}) ([]byte, error) {

--- a/repo.go
+++ b/repo.go
@@ -993,15 +993,14 @@ func (r *Repo) Commit() error {
 		return err
 	}
 
-	if err := r.local.Commit(root.ConsistentSnapshot, versions, hashes); err != nil {
-		return err
+	err = r.local.Commit(root.ConsistentSnapshot, versions, hashes)
+	if err == nil {
+		// We can start incrementing version numbers again now that we've
+		// successfully committed the metadata to the local store.
+		r.versionUpdated = make(map[string]struct{})
+		fmt.Println("Committed successfully")
 	}
-
-	// We can start incrementing version numbers again now that we've
-	// successfully committed the metadata to the local store.
-	r.versionUpdated = make(map[string]struct{})
-
-	return nil
+	return err
 }
 
 func (r *Repo) Clean() error {

--- a/repo.go
+++ b/repo.go
@@ -715,7 +715,15 @@ func (r *Repo) AddTargetsWithExpires(paths []string, custom json.RawMessage, exp
 		t.Version++
 		r.versionUpdated["targets.json"] = struct{}{}
 	}
-	return r.setMeta("targets.json", t)
+
+	err = r.setMeta("targets.json", t)
+	if err == nil {
+		fmt.Println("Targets that are currently added/staged:")
+		for k := range t.Targets {
+			fmt.Println("*", k)
+		}
+	}
+	return err
 }
 
 func (r *Repo) RemoveTarget(path string) error {

--- a/repo.go
+++ b/repo.go
@@ -478,7 +478,7 @@ func (r *Repo) RevokeKeyWithExpires(keyRole, id string, expires time.Time) error
 
 	err = r.setMeta("root.json", root)
 	if err == nil {
-		fmt.Println("Revoked", keyRole, "key with ID", id)
+		fmt.Println("Revoked", keyRole, "key with ID", id, "in root metadata")
 	}
 	return err
 }

--- a/repo.go
+++ b/repo.go
@@ -103,7 +103,11 @@ func (r *Repo) Init(consistentSnapshot bool) error {
 	}
 	root := data.NewRoot()
 	root.ConsistentSnapshot = consistentSnapshot
-	return r.setMeta("root.json", root)
+	err = r.setMeta("root.json", root)
+	if err == nil {
+		fmt.Println("Repository initialized")
+	}
+	return err
 }
 
 func (r *Repo) db() (*verify.DB, error) {

--- a/repo.go
+++ b/repo.go
@@ -537,7 +537,11 @@ func (r *Repo) Sign(roleFilename string) error {
 		return err
 	}
 	r.meta[roleFilename] = b
-	return r.local.SetMeta(roleFilename, b)
+	err = r.local.SetMeta(roleFilename, b)
+	if err == nil {
+		fmt.Println("Signed", roleFilename, "with", len(keys), "key(s)")
+	}
+	return err
 }
 
 // AddOrUpdateSignature allows users to add or update a signature generated with an external tool.

--- a/repo.go
+++ b/repo.go
@@ -865,7 +865,12 @@ func (r *Repo) TimestampWithExpires(expires time.Time) error {
 		timestamp.Version++
 		r.versionUpdated["timestamp.json"] = struct{}{}
 	}
-	return r.setMeta("timestamp.json", timestamp)
+
+	err = r.setMeta("timestamp.json", timestamp)
+	if err == nil {
+		fmt.Println("Staged timestamp.json metadata with expiration date:", timestamp.Expires)
+	}
+	return err
 }
 
 func (r *Repo) fileVersions() (map[string]int, error) {

--- a/repo.go
+++ b/repo.go
@@ -1004,7 +1004,11 @@ func (r *Repo) Commit() error {
 }
 
 func (r *Repo) Clean() error {
-	return r.local.Clean()
+	err := r.local.Clean()
+	if err == nil {
+		fmt.Println("Removed all staged metadata and target files")
+	}
+	return err
 }
 
 func (r *Repo) verifySignature(roleFilename string, db *verify.DB) error {

--- a/repo.go
+++ b/repo.go
@@ -829,7 +829,11 @@ func (r *Repo) SnapshotWithExpires(expires time.Time) error {
 		snapshot.Version++
 		r.versionUpdated["snapshot.json"] = struct{}{}
 	}
-	return r.setMeta("snapshot.json", snapshot)
+	err = r.setMeta("snapshot.json", snapshot)
+	if err == nil {
+		fmt.Println("Staged snapshot.json metadata with expiration date:", snapshot.Expires)
+	}
+	return err
 }
 
 func (r *Repo) Timestamp() error {


### PR DESCRIPTION
The following PR adds informative messages about each CLI command upon successful completion. Closes #11 

One thing I'd like to note is the output for `tuf root-keys` previously consisted only of the JSON encoded root keys and now there's a helpful message before that. This might break stuff in case there's some automation built around it, so let me know if it might make sense to revert that change specifically. 


Examples of the resulting output:

```bash
./tuf init
Repository initialized
------------
# Same for root, targets, snapshot and timestamp
./tuf gen-key root
Enter root keys passphrase: 
Repeat root keys passphrase: 
Generated root key with ID 157a50daaa57d68518ea1a47190e9ffd4be1985647f320409fa28d8c07b1ab6a
------------
./tuf revoke-key root a94ce6fd989d04d5d86202a80b320b3ab1ae60d44c693aad41be76ab5e6f568c
Revoked root key with ID a94ce6fd989d04d5d86202a80b320b3ab1ae60d44c693aad41be76ab5e6f568c
------------
./tuf sign root.json
Signed root.json with 1 key(s)
------------
./tuf add bb/cc/aa
Added/staged targets:
* bb/cc/aa
------------
./tuf add
Added/staged targets:
* bb/vv
* bbbb
* bb/cc/aa
* aaaa
------------
./tuf remove bb/vv
Removed targets:
* bb/vv
Added/staged targets:
* aaaa
* bb/cc/aa
* bbbb
------------
./tuf remove --all
Removed targets:
* aaaa
* bb/cc/aa
* bbbb
There are no added/staged targets
------------
./tuf snapshot
Staged snapshot.json metadata with expiration date: 2021-10-06 10:56:49 +0000 UTC
------------
./tuf timestamp
Staged timestamp.json metadata with expiration date: 2021-09-30 10:57:27 +0000 UTC
------------
./tuf set-threshold root 2
The threshold for root role is 2
------------
./tuf get-threshold targets
The threshold for targets role is 1
------------
./tuf commit
Committed successfully
------------
./tuf root-keys
The resulting JSON should be distributed to clients for performing initial updates:

[{"keytype":"ed25519","scheme":"ed25519","keyid_hash_algorithms":["sha256","sha512"],"keyval":{"public":"3e15b2f364cd35f2a2ee3019089e9dace8fa6daaaa2a895ff0ad13f6d365d9b2"}}]
------------
./tuf clean
Removed all staged metadata and target files
```
