### PR TITLE
add custom fields to all top level roles

### DIFF
--- a/data/types.go
+++ b/data/types.go
@@ -98,6 +98,7 @@ type Root struct {
 	Expires     time.Time             `json:"expires"`
 	Keys        map[string]*PublicKey `json:"keys"`
 	Roles       map[string]*Role      `json:"roles"`
+	Custom      *json.RawMessage      `json:"custom,omitempty"`
 
 	ConsistentSnapshot bool `json:"consistent_snapshot"`
 }
@@ -170,11 +171,12 @@ type SnapshotFileMeta struct {
 type SnapshotFiles map[string]SnapshotFileMeta
 
 type Snapshot struct {
-	Type        string        `json:"_type"`
-	SpecVersion string        `json:"spec_version"`
-	Version     int           `json:"version"`
-	Expires     time.Time     `json:"expires"`
-	Meta        SnapshotFiles `json:"meta"`
+	Type        string           `json:"_type"`
+	SpecVersion string           `json:"spec_version"`
+	Version     int              `json:"version"`
+	Expires     time.Time        `json:"expires"`
+	Meta        SnapshotFiles    `json:"meta"`
+	Custom      *json.RawMessage `json:"custom,omitempty"`
 }
 
 func NewSnapshot() *Snapshot {
@@ -197,12 +199,13 @@ func (f TargetFileMeta) HashAlgorithms() []string {
 }
 
 type Targets struct {
-	Type        string       `json:"_type"`
-	SpecVersion string       `json:"spec_version"`
-	Version     int          `json:"version"`
-	Expires     time.Time    `json:"expires"`
-	Targets     TargetFiles  `json:"targets"`
-	Delegations *Delegations `json:"delegations,omitempty"`
+	Type        string           `json:"_type"`
+	SpecVersion string           `json:"spec_version"`
+	Version     int              `json:"version"`
+	Expires     time.Time        `json:"expires"`
+	Targets     TargetFiles      `json:"targets"`
+	Delegations *Delegations     `json:"delegations,omitempty"`
+	Custom      *json.RawMessage `json:"custom,omitempty"`
 }
 
 // Delegations represents the edges from a parent Targets role to one or more
@@ -303,11 +306,12 @@ type TimestampFileMeta struct {
 type TimestampFiles map[string]TimestampFileMeta
 
 type Timestamp struct {
-	Type        string         `json:"_type"`
-	SpecVersion string         `json:"spec_version"`
-	Version     int            `json:"version"`
-	Expires     time.Time      `json:"expires"`
-	Meta        TimestampFiles `json:"meta"`
+	Type        string           `json:"_type"`
+	SpecVersion string           `json:"spec_version"`
+	Version     int              `json:"version"`
+	Expires     time.Time        `json:"expires"`
+	Meta        TimestampFiles   `json:"meta"`
+	Custom      *json.RawMessage `json:"custom,omitempty"`
 }
 
 func NewTimestamp() *Timestamp {

--- a/data/types_test.go
+++ b/data/types_test.go
@@ -246,7 +246,7 @@ func TestCustomField(t *testing.T) {
 	root := Root{
 		Type:               "root",
 		SpecVersion:        "1.0",
-		Keys:               make(map[string]*Key),
+		Keys:               make(map[string]*PublicKey),
 		Roles:              make(map[string]*Role),
 		ConsistentSnapshot: true,
 		Custom:             &testCustomJSON,

--- a/data/types_test.go
+++ b/data/types_test.go
@@ -239,3 +239,49 @@ func TestDelegatedRoleUnmarshalErr(t *testing.T) {
 	err := json.Unmarshal([]byte(`{"keyids":"a"}`), &d)
 	assert.Equal(t, "keyids", err.(*json.UnmarshalTypeError).Field)
 }
+
+func TestCustomField(t *testing.T) {
+	testCustomJSON := json.RawMessage([]byte(`{"test":true}`))
+
+	root := Root{
+		Type:               "root",
+		SpecVersion:        "1.0",
+		Keys:               make(map[string]*Key),
+		Roles:              make(map[string]*Role),
+		ConsistentSnapshot: true,
+		Custom:             &testCustomJSON,
+	}
+	rootJSON, err := json.Marshal(&root)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("{\"_type\":\"root\",\"spec_version\":\"1.0\",\"version\":0,\"expires\":\"0001-01-01T00:00:00Z\",\"keys\":{},\"roles\":{},\"custom\":{\"test\":true},\"consistent_snapshot\":true}"), rootJSON)
+
+	targets := Targets{
+		Type:        "targets",
+		SpecVersion: "1.0",
+		Targets:     make(TargetFiles),
+		Custom:      &testCustomJSON,
+	}
+	targetsJSON, err := json.Marshal(&targets)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("{\"_type\":\"targets\",\"spec_version\":\"1.0\",\"version\":0,\"expires\":\"0001-01-01T00:00:00Z\",\"targets\":{},\"custom\":{\"test\":true}}"), targetsJSON)
+
+	snapshot := Snapshot{
+		Type:        "snapshot",
+		SpecVersion: "1.0",
+		Meta:        make(SnapshotFiles),
+		Custom:      &testCustomJSON,
+	}
+	snapshotJSON, err := json.Marshal(&snapshot)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("{\"_type\":\"snapshot\",\"spec_version\":\"1.0\",\"version\":0,\"expires\":\"0001-01-01T00:00:00Z\",\"meta\":{},\"custom\":{\"test\":true}}"), snapshotJSON)
+
+	timestamp := Timestamp{
+		Type:        "timestamp",
+		SpecVersion: "1.0",
+		Meta:        make(TimestampFiles),
+		Custom:      &testCustomJSON,
+	}
+	timestampJSON, err := json.Marshal(&timestamp)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("{\"_type\":\"timestamp\",\"spec_version\":\"1.0\",\"version\":0,\"expires\":\"0001-01-01T00:00:00Z\",\"meta\":{},\"custom\":{\"test\":true}}"), timestampJSON)
+}


### PR DESCRIPTION
### What does this PR do ?

We are looking to add custom metadata to `root` and `targets` roles. I'm also adding the same custom filed to `snapshot` and `timestamp` to align all the roles nicely.

Relevant entry in the specification: 
> 4. Document formats
>All of the formats described below include the ability to add more attribute-value fields to objects for backwards-compatible format changes. Implementers who encounter undefined attribute-value pairs in the format must include the data when calculating hashes or verifying signatures and must preserve the data when re-serializing. If a backwards incompatible format change is needed, a new filename can be used.

https://theupdateframework.github.io/specification/latest/#document-formats

