### PR TITLE
Add support for changing keys file passphrase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 cmd/tuf/tuf
 cmd/tuf-client/tuf-client
+.vscode

--- a/README.md
+++ b/README.md
@@ -124,12 +124,15 @@ Outputs `role`'s threshold (required number of keys for signing).
 
 #### `tuf change-passphrase <role>`
 
-Changes the passphrase for given role keys file.
+Changes the passphrase for given role keys file. The CLI supports reading
+both the existing and the new passphrase via the following environment
+variables - `TUF_{{ROLE}}_PASSPHRASE` and respectively `TUF_NEW_{{ROLE}}_PASSPHRASE`
 
 #### Usage of environment variables
 
 The `tuf` CLI supports receiving passphrases via environment variables in
-the form of `TUF_{{ROLE}}_PASSPHRASE`
+the form of `TUF_{{ROLE}}_PASSPHRASE` for existing ones and
+`TUF_NEW_{{ROLE}}_PASSPHRASE` for setting new ones.
 
 For a list of supported commands, run `tuf help` from the command line.
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ Sets `role`'s threshold (required number of keys for signing) to
 
 Outputs `role`'s threshold (required number of keys for signing).
 
+#### `tuf change-passphrase <role>`
+
+Changes the passphrase for given role keys file.
+
 #### Usage of environment variables
 
 The `tuf` CLI supports receiving passphrases via environment variables in

--- a/cmd/tuf/change_passphrase.go
+++ b/cmd/tuf/change_passphrase.go
@@ -12,7 +12,8 @@ usage: tuf change-passphrase <role>
 Changes the passphrase for given role keys file.
 
 Alternatively, passphrases can be passed via environment variables in the
-form of TUF_{{ROLE}}_PASSPHRASE
+form of TUF_{{ROLE}}_PASSPHRASE for existing ones and
+TUF_NEW_{{ROLE}}_PASSPHRASE for setting new ones.
 `)
 }
 

--- a/cmd/tuf/change_passphrase.go
+++ b/cmd/tuf/change_passphrase.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"github.com/flynn/go-docopt"
+	"github.com/theupdateframework/go-tuf"
+)
+
+func init() {
+	register("change-passphrase", cmdChangePassphrase, `
+usage: tuf change-passphrase <role>
+
+Changes the passphrase for given role keys file.
+
+Alternatively, passphrases can be passed via environment variables in the
+form of TUF_{{ROLE}}_PASSPHRASE
+`)
+}
+
+func cmdChangePassphrase(args *docopt.Args, repo *tuf.Repo) error {
+	return repo.ChangePassphrase(args.String["<role>"])
+}

--- a/cmd/tuf/main.go
+++ b/cmd/tuf/main.go
@@ -134,6 +134,12 @@ func getPassphrase(role string, confirm bool, change bool) ([]byte, error) {
 	}
 	// Alter role string if we are prompting for a passphrase change
 	if change {
+		// Check if environment variable for new passphrase exist
+		if new_pass := os.Getenv(fmt.Sprintf("TUF_NEW_%s_PASSPHRASE", strings.ToUpper(role))); new_pass != "" {
+			// If so, just read the new passphrase from it and return
+			return []byte(new_pass), nil
+		}
+		// No environment variable set, so proceed prompting for new passphrase
 		role = fmt.Sprintf("new %s", role)
 	}
 	fmt.Printf("Enter %s keys passphrase: ", role)

--- a/cmd/tuf/main.go
+++ b/cmd/tuf/main.go
@@ -127,7 +127,9 @@ func parseExpires(arg string) (time.Time, error) {
 }
 
 func getPassphrase(role string, confirm bool, change bool) ([]byte, error) {
-	if pass := os.Getenv(fmt.Sprintf("TUF_%s_PASSPHRASE", strings.ToUpper(role))); pass != "" {
+	// In case of change we need to prompt explicitly for a new passphrase
+	// and not read it from the environment variable, if present
+	if pass := os.Getenv(fmt.Sprintf("TUF_%s_PASSPHRASE", strings.ToUpper(role))); pass != "" && !change {
 		return []byte(pass), nil
 	}
 	// Alter role string if we are prompting for a passphrase change

--- a/cmd/tuf/main.go
+++ b/cmd/tuf/main.go
@@ -126,11 +126,14 @@ func parseExpires(arg string) (time.Time, error) {
 	return time.Now().AddDate(0, 0, days).UTC(), nil
 }
 
-func getPassphrase(role string, confirm bool) ([]byte, error) {
+func getPassphrase(role string, confirm bool, change bool) ([]byte, error) {
 	if pass := os.Getenv(fmt.Sprintf("TUF_%s_PASSPHRASE", strings.ToUpper(role))); pass != "" {
 		return []byte(pass), nil
 	}
-
+	// Alter role string if we are prompting for a passphrase change
+	if change {
+		role = fmt.Sprintf("new %s", role)
+	}
 	fmt.Printf("Enter %s keys passphrase: ", role)
 	passphrase, err := terminal.ReadPassword(int(syscall.Stdin))
 	fmt.Println()

--- a/cmd/tuf/main.go
+++ b/cmd/tuf/main.go
@@ -28,21 +28,22 @@ Options:
   --insecure-plaintext  Don't encrypt signing keys
 
 Commands:
-  help          Show usage for a specific command
-  init          Initialize a new repository
-  gen-key       Generate a new signing key for a specific metadata file
-  revoke-key    Revoke a signing key
-  add           Add target file(s)
-  remove        Remove a target file
-  snapshot      Update the snapshot metadata file
-  timestamp     Update the timestamp metadata file
-  sign          Sign a role's metadata file
-  commit        Commit staged files to the repository
-  regenerate    Recreate the targets metadata file [Not supported yet]
-  clean         Remove all staged metadata files
-  root-keys     Output a JSON serialized array of root keys to STDOUT
-  set-threshold Sets the threshold for a role
-  get-threshold Outputs the threshold for a role
+  help               Show usage for a specific command
+  init               Initialize a new repository
+  gen-key            Generate a new signing key for a specific metadata file
+  revoke-key         Revoke a signing key
+  add                Add target file(s)
+  remove             Remove a target file
+  snapshot           Update the snapshot metadata file
+  timestamp          Update the timestamp metadata file
+  sign               Sign a role's metadata file
+  commit             Commit staged files to the repository
+  regenerate         Recreate the targets metadata file [Not supported yet]
+  set-threshold      Sets the threshold for a role
+  get-threshold      Outputs the threshold for a role
+  change-passphrase  Changes the passphrase for given role keys file
+  root-keys          Output a JSON serialized array of root keys to STDOUT
+  clean              Remove all staged metadata files
 
 See "tuf help <command>" for more information on a specific command
 `

--- a/errors.go
+++ b/errors.go
@@ -7,8 +7,9 @@ import (
 )
 
 var (
-	ErrInitNotAllowed = errors.New("tuf: repository already initialized")
-	ErrNewRepository  = errors.New("tuf: repository not yet committed")
+	ErrInitNotAllowed               = errors.New("tuf: repository already initialized")
+	ErrNewRepository                = errors.New("tuf: repository not yet committed")
+	ErrChangePassphraseNotSupported = errors.New("tuf: store does not support changing passphrase")
 )
 
 type ErrMissingMetadata struct {

--- a/local_store.go
+++ b/local_store.go
@@ -352,8 +352,7 @@ func (f *fileSystemStore) ChangePassphrase(role string) error {
 		return err
 	}
 	// Prompt for new passphrase
-	fmt.Println("Enter your new", role, "keys passphrase")
-	pass, err := f.passphraseFunc(role, true)
+	pass, err := f.passphraseFunc(role, true, true)
 	if err != nil {
 		return err
 	}
@@ -370,7 +369,7 @@ func (f *fileSystemStore) ChangePassphrase(role string) error {
 	if err := util.AtomicallyWriteFile(f.keysPath(role), append(data, '\n'), 0600); err != nil {
 		return err
 	}
-	fmt.Println("Passphrase for", role, "keys file changed successfully")
+	fmt.Printf("Successfully changed passphrase for %s keys file\n", role)
 	return nil
 }
 
@@ -395,7 +394,7 @@ func (f *fileSystemStore) SaveSigner(role string, signer keys.Signer) error {
 	// be encrypted later (passphraseFunc being nil indicates the keys file
 	// should not be encrypted)
 	if pass == nil && f.passphraseFunc != nil {
-		pass, err = f.passphraseFunc(role, true)
+		pass, err = f.passphraseFunc(role, true, false)
 		if err != nil {
 			return err
 		}
@@ -455,7 +454,7 @@ func (f *fileSystemStore) loadPrivateKeys(role string) ([]*data.PrivateKey, []by
 	// try the empty string as the password first
 	pass := []byte("")
 	if err := encrypted.Unmarshal(pk.Data, &keys, pass); err != nil {
-		pass, err = f.passphraseFunc(role, false)
+		pass, err = f.passphraseFunc(role, false, false)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/local_store.go
+++ b/local_store.go
@@ -95,13 +95,6 @@ func (m *memoryStore) Commit(consistentSnapshot bool, versions map[string]int, h
 	return nil
 }
 
-// ChangePassphrase changes the passphrase for a role keys file
-func (f *memoryStore) ChangePassphrase(role string) error {
-	/* Not needed, keys are not stored nor encrypted
-	anywhere with this type of storage backend */
-	return nil
-}
-
 func (m *memoryStore) GetSigners(role string) ([]keys.Signer, error) {
 	return m.signers[role], nil
 }
@@ -339,7 +332,8 @@ func (f *fileSystemStore) GetSigners(role string) ([]keys.Signer, error) {
 	return f.signers[role], nil
 }
 
-// ChangePassphrase changes the passphrase for a role keys file
+// ChangePassphrase changes the passphrase for a role keys file. Implements
+// PassphraseChanger interface.
 func (f *fileSystemStore) ChangePassphrase(role string) error {
 	// No need to proceed if passphrase func is not set
 	if f.passphraseFunc == nil {

--- a/local_store.go
+++ b/local_store.go
@@ -348,7 +348,10 @@ func (f *fileSystemStore) ChangePassphrase(role string) error {
 	// Read the existing keys (if any)
 	// If encrypted, will prompt for existing passphrase
 	keys, _, err := f.loadPrivateKeys(role)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil {
+		if os.IsNotExist(err) {
+			fmt.Printf("Failed to change passphrase. Missing keys file for %s role. \n", role)
+		}
 		return err
 	}
 	// Prompt for new passphrase

--- a/repo.go
+++ b/repo.go
@@ -55,8 +55,11 @@ type LocalStore interface {
 	// GetSigners return a list of signers for a role.
 	GetSigners(string) ([]keys.Signer, error)
 
-	// SavePrivateKey adds a signer to a role.
+	// SaveSigner adds a signer to a role.
 	SaveSigner(string, keys.Signer) error
+
+	// ChangePassphrase changes the passphrase for a role keys file.
+	ChangePassphrase(string) error
 
 	// Clean is used to remove all staged metadata files.
 	Clean() error
@@ -311,6 +314,13 @@ func (r *Repo) timestamp() (*data.Timestamp, error) {
 		return nil, err
 	}
 	return timestamp, nil
+}
+
+func (r *Repo) ChangePassphrase(keyRole string) error {
+	if !verify.ValidRole(keyRole) {
+		return ErrInvalidRole{keyRole}
+	}
+	return r.local.ChangePassphrase(keyRole)
 }
 
 func (r *Repo) GenKey(role string) ([]string, error) {

--- a/repo.go
+++ b/repo.go
@@ -58,11 +58,13 @@ type LocalStore interface {
 	// SaveSigner adds a signer to a role.
 	SaveSigner(string, keys.Signer) error
 
-	// ChangePassphrase changes the passphrase for a role keys file.
-	ChangePassphrase(string) error
-
 	// Clean is used to remove all staged metadata files.
 	Clean() error
+}
+
+type PassphraseChanger interface {
+	// ChangePassphrase changes the passphrase for a role keys file.
+	ChangePassphrase(string) error
 }
 
 type Repo struct {
@@ -320,7 +322,12 @@ func (r *Repo) ChangePassphrase(keyRole string) error {
 	if !verify.ValidRole(keyRole) {
 		return ErrInvalidRole{keyRole}
 	}
-	return r.local.ChangePassphrase(keyRole)
+
+	if p, ok := r.local.(PassphraseChanger); ok {
+		return p.ChangePassphrase(keyRole)
+	}
+
+	return ErrChangePassphraseNotSupported
 }
 
 func (r *Repo) GenKey(role string) ([]string, error) {

--- a/repo_test.go
+++ b/repo_test.go
@@ -1381,7 +1381,7 @@ func (rs *RepoSuite) TestKeyPersistence(c *C) {
 	store = FileSystemStore(tmp.path, testPassphraseFunc)
 
 	// 2. Test changing the passphrase when the keys file does not exist - should FAIL
-	c.Assert(store.ChangePassphrase("root"), NotNil)
+	c.Assert(store.(PassphraseChanger).ChangePassphrase("root"), NotNil)
 
 	// 3. Generate a new key
 	signer, err = keys.GenerateEd25519Key()
@@ -1394,7 +1394,7 @@ func (rs *RepoSuite) TestKeyPersistence(c *C) {
 	assertKeys("root", true, []*data.PrivateKey{privateKey})
 
 	// 5. Change the passphrase (our mock passphrase function is called with change=true thus returning the newPassphrase value)
-	c.Assert(store.ChangePassphrase("root"), IsNil)
+	c.Assert(store.(PassphraseChanger).ChangePassphrase("root"), IsNil)
 
 	// 6. Try to add a key and implicitly decrypt the keys file using the OLD passphrase - should FAIL
 	newKey, err = keys.GenerateEd25519Key()

--- a/repo_test.go
+++ b/repo_test.go
@@ -1256,7 +1256,7 @@ func (rs *RepoSuite) TestHashAlgorithm(c *C) {
 }
 
 func testPassphraseFunc(p []byte) util.PassphraseFunc {
-	return func(string, bool) ([]byte, error) { return p, nil }
+	return func(string, bool, bool) ([]byte, error) { return p, nil }
 }
 
 func (rs *RepoSuite) TestKeyPersistence(c *C) {

--- a/repo_test.go
+++ b/repo_test.go
@@ -1255,14 +1255,20 @@ func (rs *RepoSuite) TestHashAlgorithm(c *C) {
 	}
 }
 
-func testPassphraseFunc(p []byte) util.PassphraseFunc {
-	return func(string, bool, bool) ([]byte, error) { return p, nil }
-}
-
 func (rs *RepoSuite) TestKeyPersistence(c *C) {
 	tmp := newTmpDir(c)
-	passphrase := []byte("s3cr3t")
-	store := FileSystemStore(tmp.path, testPassphraseFunc(passphrase))
+	oldPassphrase := []byte("old_s3cr3t")
+	newPassphrase := []byte("new_s3cr3t")
+	// returnNewPassphrase is used to force the passphrase function to return the new passphrase when called by the SaveSigner() method
+	returnNewPassphrase := false
+	// passphrase mock function
+	testPassphraseFunc := func(a string, b, change bool) ([]byte, error) {
+		if change || returnNewPassphrase {
+			return newPassphrase, nil
+		}
+		return oldPassphrase, nil
+	}
+	store := FileSystemStore(tmp.path, testPassphraseFunc)
 
 	assertKeys := func(role string, enc bool, expected []*data.PrivateKey) {
 		keysJSON := tmp.readFile("keys/" + role + ".json")
@@ -1271,9 +1277,13 @@ func (rs *RepoSuite) TestKeyPersistence(c *C) {
 
 		// check the persisted keys are correct
 		var actual []*data.PrivateKey
+		pass := oldPassphrase
 		if enc {
 			c.Assert(pk.Encrypted, Equals, true)
-			decrypted, err := encrypted.Decrypt(pk.Data, passphrase)
+			if returnNewPassphrase {
+				pass = newPassphrase
+			}
+			decrypted, err := encrypted.Decrypt(pk.Data, pass)
 			c.Assert(err, IsNil)
 			c.Assert(json.Unmarshal(decrypted, &actual), IsNil)
 		} else {
@@ -1364,6 +1374,45 @@ func (rs *RepoSuite) TestKeyPersistence(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(insecureStore.SaveSigner("targets", signer), IsNil)
 	assertKeys("targets", false, []*data.PrivateKey{privateKey})
+
+	// Test changing the passphrase
+	// 1. Create a secure store with a passphrase (create new object and temp folder so we discard any previous state)
+	tmp = newTmpDir(c)
+	store = FileSystemStore(tmp.path, testPassphraseFunc)
+
+	// 2. Test changing the passphrase when the keys file does not exist - should FAIL
+	c.Assert(store.ChangePassphrase("root"), NotNil)
+
+	// 3. Generate a new key
+	signer, err = keys.GenerateEd25519Key()
+	c.Assert(err, IsNil)
+	privateKey, err = signer.MarshalPrivateKey()
+	c.Assert(err, IsNil)
+	c.Assert(store.SaveSigner("root", signer), IsNil)
+
+	// 4. Verify the key file can be decrypted using the original passphrase - should SUCCEED
+	assertKeys("root", true, []*data.PrivateKey{privateKey})
+
+	// 5. Change the passphrase (our mock passphrase function is called with change=true thus returning the newPassphrase value)
+	c.Assert(store.ChangePassphrase("root"), IsNil)
+
+	// 6. Try to add a key and implicitly decrypt the keys file using the OLD passphrase - should FAIL
+	newKey, err = keys.GenerateEd25519Key()
+	c.Assert(err, IsNil)
+	newPrivateKey, err = newKey.MarshalPrivateKey()
+	c.Assert(err, IsNil)
+	c.Assert(store.SaveSigner("root", newKey), NotNil)
+
+	// 7. Try to add a key and implicitly decrypt the keys using the NEW passphrase - should SUCCEED
+	returnNewPassphrase = true
+	newKey, err = keys.GenerateEd25519Key()
+	c.Assert(err, IsNil)
+	newPrivateKey, err = newKey.MarshalPrivateKey()
+	c.Assert(err, IsNil)
+	c.Assert(store.SaveSigner("root", newKey), IsNil)
+
+	// 8. Verify again that the key entries are what we expect after decrypting them using the NEW passphrase
+	assertKeys("root", true, []*data.PrivateKey{privateKey, newPrivateKey})
 }
 
 func (rs *RepoSuite) TestManageMultipleTargets(c *C) {

--- a/util/util.go
+++ b/util/util.go
@@ -72,7 +72,7 @@ func (e ErrUnknownHashAlgorithm) Error() string {
 	return fmt.Sprintf("unknown hash algorithm: %s", e.Name)
 }
 
-type PassphraseFunc func(role string, confirm bool) ([]byte, error)
+type PassphraseFunc func(role string, confirm bool, change bool) ([]byte, error)
 
 func FileMetaEqual(actual data.FileMeta, expected data.FileMeta) error {
 	if actual.Length != expected.Length {


### PR DESCRIPTION
The following PR adds support for changing the passphrase for a given role keys file. 

Closes #60 

The format of the command is `tuf change-passphrase <role>`. Example usage:

* In case the keys file exist - 

```bash
tuf change-passphrase root
Enter root keys passphrase: 
Enter new root keys passphrase: 
Repeat new root keys passphrase: 
Successfully changed passphrase for root keys file
```

* In case the keys file doesn't exist yet - 

```bash
tuf change-passphrase snapshot
Failed to change passphrase. Missing keys file for snapshot role. 
ERROR: open <path>/go-tuf/cmd/tuf/keys/snapshot.json: no such file or directory
```