### PR TITLE
bugfix: Fix key revocation when key is shared between roles

### DIFF
--- a/repo.go
+++ b/repo.go
@@ -469,16 +469,17 @@ func (r *Repo) RevokeKeyWithExpires(keyRole, id string, expires time.Time) error
 	role.KeyIDs = keyIDs
 	root.Roles[keyRole] = role
 
-	// Only delete the key from root.Keys if no other role is using that key.
-	delete_key := true
+	// Only delete the key from root.Keys if the key is no longer in use by
+	// any other role.
+	key_in_use := true
 	for _, role := range root.Roles {
 		for _, keyID := range role.KeyIDs {
 			if key.ContainsID(keyID) {
-				delete_key = false
+				key_in_use = false
 			}
 		}
 	}
-	if delete_key {
+	if key_in_use {
 		for _, keyID := range key.IDs() {
 			delete(root.Keys, keyID)
 		}

--- a/repo.go
+++ b/repo.go
@@ -459,10 +459,9 @@ func (r *Repo) RevokeKeyWithExpires(keyRole, id string, expires time.Time) error
 	// There may be multiple keyids that correspond to this key, so
 	// filter all of them out.
 	for _, keyID := range role.KeyIDs {
-		if key.ContainsID(keyID) {
-			continue
+		if !key.ContainsID(keyID) {
+			filteredKeyIDs = append(filteredKeyIDs, keyID)
 		}
-		filteredKeyIDs = append(filteredKeyIDs, keyID)
 	}
 	if len(filteredKeyIDs) == len(role.KeyIDs) {
 		return ErrKeyNotFound{keyRole, id}
@@ -472,15 +471,15 @@ func (r *Repo) RevokeKeyWithExpires(keyRole, id string, expires time.Time) error
 
 	// Only delete the key from root.Keys if the key is no longer in use by
 	// any other role.
-	key_in_use := true
+	key_in_use := false
 	for _, role := range root.Roles {
 		for _, keyID := range role.KeyIDs {
 			if key.ContainsID(keyID) {
-				key_in_use = false
+				key_in_use = true
 			}
 		}
 	}
-	if key_in_use {
+	if !key_in_use {
 		for _, keyID := range key.IDs() {
 			delete(root.Keys, keyID)
 		}

--- a/repo.go
+++ b/repo.go
@@ -453,7 +453,8 @@ func (r *Repo) RevokeKeyWithExpires(keyRole, id string, expires time.Time) error
 		return ErrKeyNotFound{keyRole, id}
 	}
 
-	keyIDs := make([]string, 0, len(role.KeyIDs))
+	// Create a list of filtered key IDs that do not contain the revoked key IDs.
+	filteredKeyIDs := make([]string, 0, len(role.KeyIDs))
 
 	// There may be multiple keyids that correspond to this key, so
 	// filter all of them out.
@@ -461,12 +462,12 @@ func (r *Repo) RevokeKeyWithExpires(keyRole, id string, expires time.Time) error
 		if key.ContainsID(keyID) {
 			continue
 		}
-		keyIDs = append(keyIDs, keyID)
+		filteredKeyIDs = append(filteredKeyIDs, keyID)
 	}
-	if len(keyIDs) == len(role.KeyIDs) {
+	if len(filteredKeyIDs) == len(role.KeyIDs) {
 		return ErrKeyNotFound{keyRole, id}
 	}
-	role.KeyIDs = keyIDs
+	role.KeyIDs = filteredKeyIDs
 	root.Roles[keyRole] = role
 
 	// Only delete the key from root.Keys if the key is no longer in use by


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

As noted in issue https://github.com/theupdateframework/go-tuf/issues/167, when a key that is used between multiple roles (e.g. roleA and roleB) is revoked from roleA, the key is still deleted from `root.Keys`, so roleB is left in a bad state where its key is not present in root.Keys.

This fixes that by only deleting the key from `root.Keys` if NO role is using the key anymore. Added a test that would previously fail.