### PR TITLE
Add digest to targets metadata directly

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -851,7 +851,7 @@ func (c *Client) VerifyDigest(digest string, digestAlg string, length int64, pat
 		return err
 	}
 
-	if err := util.TargetFileMetaEqual(data.TargetFileMeta{actual}, localMeta); err != nil {
+	if err := util.TargetFileMetaEqual(data.TargetFileMeta{FileMeta: actual}, localMeta); err != nil {
 		if e, ok := err.(util.ErrWrongLength); ok {
 			return ErrWrongSize{path, e.Actual, e.Expected}
 		}

--- a/client/client.go
+++ b/client/client.go
@@ -842,7 +842,7 @@ func (c *Client) Download(name string, dest Destination) (err error) {
 	return nil
 }
 
-func (c *Client) VerifyDigest(digest string, digestAlg string, length int64, path string) (err error) {
+func (c *Client) VerifyDigest(digest string, digestAlg string, length int64, path string) error {
 	localMeta, ok := c.targets[path]
 	if !ok {
 		return ErrUnknownTarget{Name: path, SnapshotVersion: c.snapshotVer}

--- a/client/client.go
+++ b/client/client.go
@@ -849,6 +849,7 @@ func (c *Client) VerifyDigest(digest string, digestAlg string, length int64, pat
 	}
 
 	actual := data.FileMeta{Length: length, Hashes: make(data.Hashes, 1)}
+	var err error
 	actual.Hashes[digestAlg], err = hex.DecodeString(digest)
 	if err != nil {
 		return err

--- a/client/client.go
+++ b/client/client.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+	"strings"
 
 	"github.com/theupdateframework/go-tuf/data"
 	"github.com/theupdateframework/go-tuf/util"
@@ -842,8 +843,12 @@ func (c *Client) Download(name string, dest Destination) (err error) {
 	return nil
 }
 
-func (c *Client) VerifyDigest(digest string, length int64) (err error) {
-	localMeta, _ := c.targets[digest]
+func (c *Client) VerifyDigest(digest string, length int64, path string) (err error) {
+	targetName := path
+	if path == "" {
+		targetName = digest
+	}
+	localMeta, _ := c.targets[targetName]
 
 	hashes := make([]string, 1)
 	hashes[0] = strings.Split(digest, ":")[1]

--- a/client/client.go
+++ b/client/client.go
@@ -843,7 +843,10 @@ func (c *Client) Download(name string, dest Destination) (err error) {
 }
 
 func (c *Client) VerifyDigest(digest string, digestAlg string, length int64, path string) (err error) {
-	localMeta, _ := c.targets[path]
+	localMeta, ok := c.targets[path]
+	if !ok {
+		return ErrUnknownTarget{Name: path, SnapshotVersion: c.snapshotVer}
+	}
 
 	actual := data.FileMeta{Length: length, Hashes: make(data.Hashes, 1)}
 	actual.Hashes[digestAlg], err = hex.DecodeString(digest)

--- a/client/client.go
+++ b/client/client.go
@@ -847,6 +847,9 @@ func (c *Client) VerifyDigest(digest string, digestAlg string, length int64, pat
 
 	actual := data.FileMeta{Length: length, Hashes: make(data.Hashes, 1)}
 	actual.Hashes[digestAlg], err = hex.DecodeString(digest)
+	if err != nil {
+		return err
+	}
 
 	if err := util.TargetFileMetaEqual(data.TargetFileMeta{actual}, localMeta); err != nil {
 		if e, ok := err.(util.ErrWrongLength); ok {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1179,7 +1179,7 @@ func generateRepoFS(c *C, dir string, files map[string][]byte, consistentSnapsho
 	return repo
 }
 
-func (s *ClientSuite) TestVerifyDigest(c *C){
+func (s *ClientSuite) TestVerifyDigest(c *C) {
 	client := s.newClient(c)
 	files, err := client.Update()
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1184,7 +1184,7 @@ func (s *ClientSuite) TestVerifyDigest(c *C) {
 	hash := "bc11b176a293bb341a0f2d0d226f52e7fcebd186a7c4dfca5fc64f305f06b94c"
 	size := int64(42)
 
-	c.Assert(s.repo.AddDigestTargets(hash, "sha256", size, nil, digest), IsNil)
+	c.Assert(s.repo.AddTargetsWithDigest(hash, "sha256", size, nil, digest), IsNil)
 	c.Assert(s.repo.Snapshot(), IsNil)
 	c.Assert(s.repo.Timestamp(), IsNil)
 	c.Assert(s.repo.Commit(), IsNil)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1178,3 +1178,10 @@ func generateRepoFS(c *C, dir string, files map[string][]byte, consistentSnapsho
 	c.Assert(repo.Commit(), IsNil)
 	return repo
 }
+
+func (s *ClientSuite) TestVerifyDigest(c *C){
+	client := s.newClient(c)
+	files, err := client.Update()
+
+	client.VerifyDigest()
+}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1184,7 +1184,7 @@ func (s *ClientSuite) TestVerifyDigest(c *C) {
 	hash := "bc11b176a293bb341a0f2d0d226f52e7fcebd186a7c4dfca5fc64f305f06b94c"
 	size := int64(42)
 
-	c.Assert(s.repo.AddDigestTargets(digest, size, nil, ""), IsNil)
+	c.Assert(s.repo.AddDigestTargets(hash, "sha256", size, nil, digest), IsNil)
 	c.Assert(s.repo.Snapshot(), IsNil)
 	c.Assert(s.repo.Timestamp(), IsNil)
 	c.Assert(s.repo.Commit(), IsNil)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1184,7 +1184,7 @@ func (s *ClientSuite) TestVerifyDigest(c *C) {
 	hash := "bc11b176a293bb341a0f2d0d226f52e7fcebd186a7c4dfca5fc64f305f06b94c"
 	size := int64(42)
 
-	c.Assert(s.repo.AddTargetsWithDigest(hash, "sha256", size, nil, digest), IsNil)
+	c.Assert(s.repo.AddTargetsWithDigest(hash, "sha256", size, digest, nil), IsNil)
 	c.Assert(s.repo.Snapshot(), IsNil)
 	c.Assert(s.repo.Timestamp(), IsNil)
 	c.Assert(s.repo.Commit(), IsNil)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1180,8 +1180,18 @@ func generateRepoFS(c *C, dir string, files map[string][]byte, consistentSnapsho
 }
 
 func (s *ClientSuite) TestVerifyDigest(c *C) {
-	client := s.newClient(c)
-	files, err := client.Update()
+	digest := "sha256:bc11b176a293bb341a0f2d0d226f52e7fcebd186a7c4dfca5fc64f305f06b94c"
+	size := int64(42)
 
-	client.VerifyDigest()
+	c.Assert(s.repo.AddDigestTargets(digest, size, nil, ""), IsNil)
+	c.Assert(s.repo.Snapshot(), IsNil)
+	c.Assert(s.repo.Timestamp(), IsNil)
+	c.Assert(s.repo.Commit(), IsNil)
+	s.syncRemote(c)
+
+	client := s.newClient(c)
+	_, err := client.Update()
+	c.Assert(err, IsNil)
+
+	c.Assert(client.VerifyDigest(digest, size, ""), IsNil)
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1181,6 +1181,7 @@ func generateRepoFS(c *C, dir string, files map[string][]byte, consistentSnapsho
 
 func (s *ClientSuite) TestVerifyDigest(c *C) {
 	digest := "sha256:bc11b176a293bb341a0f2d0d226f52e7fcebd186a7c4dfca5fc64f305f06b94c"
+	hash := "bc11b176a293bb341a0f2d0d226f52e7fcebd186a7c4dfca5fc64f305f06b94c"
 	size := int64(42)
 
 	c.Assert(s.repo.AddDigestTargets(digest, size, nil, ""), IsNil)
@@ -1193,5 +1194,5 @@ func (s *ClientSuite) TestVerifyDigest(c *C) {
 	_, err := client.Update()
 	c.Assert(err, IsNil)
 
-	c.Assert(client.VerifyDigest(digest, size, ""), IsNil)
+	c.Assert(client.VerifyDigest(hash, "sha256", size, digest), IsNil)
 }

--- a/repo.go
+++ b/repo.go
@@ -707,6 +707,7 @@ func (r *Repo) AddTargets(paths []string, custom json.RawMessage) error {
 func (r *Repo) AddDigestTargets(digest string, length int64, custom json.RawMessage, path string) error {
 	expires := data.DefaultExpires("targets")
 
+	// TODO: support delegated targets
 	t, err := r.targets()
 	if err != nil {
 		return err

--- a/repo.go
+++ b/repo.go
@@ -712,10 +712,11 @@ func (r *Repo) AddDigestTargets(digest string, length int64, custom json.RawMess
 		return err
 	}
 	hashes := make([]string, 1)
-	hashes[0] = strings.Split(digest, ":")[1]
+	split_digest := strings.Split(digest, ":")
+	hashes[0] = split_digest[1]
 
 	meta := data.FileMeta{Length: length, Hashes: make(data.Hashes, len(hashes))}
-	meta.Hashes["sha256"], err = hex.DecodeString(hashes[0])
+	meta.Hashes[split_digest[0]], err = hex.DecodeString(hashes[0])
 
 	path := digest
 

--- a/repo.go
+++ b/repo.go
@@ -725,7 +725,7 @@ func (r *Repo) AddDigestTargets(digest string, digestAlg string, length int64, c
 		meta.Custom = t.Custom
 	}
 
-	t.Targets[path] = data.TargetFileMeta{meta}
+	t.Targets[path] = data.TargetFileMeta{FileMeta: meta}
 
 	return r.writeTargetWithExpires(t, expires)
 }

--- a/repo.go
+++ b/repo.go
@@ -704,7 +704,7 @@ func (r *Repo) AddTargets(paths []string, custom json.RawMessage) error {
 	return r.AddTargetsWithExpires(paths, custom, data.DefaultExpires("targets"))
 }
 
-func (r *Repo) AddDigestTargets(digest string, digestAlg string, length int64, custom json.RawMessage, path string) error {
+func (r *Repo) AddTargetsWithDigest(digest string, digestAlg string, length int64, custom json.RawMessage, path string) error {
 	expires := data.DefaultExpires("targets")
 
 	// TODO: support delegated targets
@@ -719,6 +719,8 @@ func (r *Repo) AddDigestTargets(digest string, digestAlg string, length int64, c
 		return err
 	}
 
+	// If custom is provided, set custom, otherwise maintain existing custom
+	// metadata
 	if len(custom) > 0 {
 		meta.Custom = &custom
 	} else if t, ok := t.Targets[path]; ok {

--- a/repo.go
+++ b/repo.go
@@ -708,7 +708,7 @@ func (r *Repo) AddTargetsWithDigest(digest string, digestAlg string, length int6
 	expires := data.DefaultExpires("targets")
 
 	// TODO: support delegated targets
-	t, err := r.targets()
+	t, err := r.topLevelTargets()
 	if err != nil {
 		return err
 	}
@@ -780,7 +780,7 @@ func (r *Repo) writeTargetWithExpires(t *data.Targets, expires time.Time) error 
 		t.Version++
 	}
 
-	err = r.setTopLevelMeta("targets.json", t)
+	err := r.setTopLevelMeta("targets.json", t)
 	if err == nil {
 		fmt.Println("Added/staged targets:")
 		for k := range t.Targets {

--- a/repo.go
+++ b/repo.go
@@ -704,7 +704,7 @@ func (r *Repo) AddTargets(paths []string, custom json.RawMessage) error {
 	return r.AddTargetsWithExpires(paths, custom, data.DefaultExpires("targets"))
 }
 
-func (r *Repo) AddTargetsWithDigest(digest string, digestAlg string, length int64, custom json.RawMessage, path string) error {
+func (r *Repo) AddTargetsWithDigest(digest string, digestAlg string, length int64, path string, custom json.RawMessage) error {
 	expires := data.DefaultExpires("targets")
 
 	// TODO: support delegated targets

--- a/repo_test.go
+++ b/repo_test.go
@@ -1812,7 +1812,7 @@ func (rs *RepoSuite) TestSignDigest(c *C) {
 	hash := "bc11b176a293bb341a0f2d0d226f52e7fcebd186a7c4dfca5fc64f305f06b94c"
 	size := int64(42)
 
-	c.Assert(r.AddDigestTargets(hash, "sha256", size, nil, digest), IsNil)
+	c.Assert(r.AddTargetsWithDigest(hash, "sha256", size, nil, digest), IsNil)
 	c.Assert(r.Snapshot(), IsNil)
 	c.Assert(r.Timestamp(), IsNil)
 	c.Assert(r.Commit(), IsNil)

--- a/repo_test.go
+++ b/repo_test.go
@@ -1821,7 +1821,7 @@ func (rs *RepoSuite) TestSignDigest(c *C) {
 	hex_digest_bytes := data.HexBytes(digest_bytes)
 	c.Assert(err, IsNil)
 
-	targets, err := r.targets()
+	targets, err := r.topLevelTargets()
 	c.Assert(err, IsNil)
 	c.Assert(targets.Targets["sha256:bc11b176a293bb341a0f2d0d226f52e7fcebd186a7c4dfca5fc64f305f06b94c"].FileMeta.Length, Equals, size)
 	c.Assert(targets.Targets["sha256:bc11b176a293bb341a0f2d0d226f52e7fcebd186a7c4dfca5fc64f305f06b94c"].FileMeta.Hashes["sha256"], DeepEquals, hex_digest_bytes)

--- a/repo_test.go
+++ b/repo_test.go
@@ -1812,7 +1812,7 @@ func (rs *RepoSuite) TestSignDigest(c *C) {
 	hash := "bc11b176a293bb341a0f2d0d226f52e7fcebd186a7c4dfca5fc64f305f06b94c"
 	size := int64(42)
 
-	c.Assert(r.AddTargetsWithDigest(hash, "sha256", size, nil, digest), IsNil)
+	c.Assert(r.AddTargetsWithDigest(hash, "sha256", size, digest, nil), IsNil)
 	c.Assert(r.Snapshot(), IsNil)
 	c.Assert(r.Timestamp(), IsNil)
 	c.Assert(r.Commit(), IsNil)

--- a/repo_test.go
+++ b/repo_test.go
@@ -1809,9 +1809,10 @@ func (rs *RepoSuite) TestSignDigest(c *C) {
 	genKey(c, r, "timestamp")
 
 	digest := "sha256:bc11b176a293bb341a0f2d0d226f52e7fcebd186a7c4dfca5fc64f305f06b94c"
+	hash := "bc11b176a293bb341a0f2d0d226f52e7fcebd186a7c4dfca5fc64f305f06b94c"
 	size := int64(42)
 
-	c.Assert(r.AddDigestTargets(digest, size, nil, ""), IsNil)
+	c.Assert(r.AddDigestTargets(hash, "sha256", size, nil, digest), IsNil)
 	c.Assert(r.Snapshot(), IsNil)
 	c.Assert(r.Timestamp(), IsNil)
 	c.Assert(r.Commit(), IsNil)

--- a/repo_test.go
+++ b/repo_test.go
@@ -1797,7 +1797,7 @@ func (rs *RepoSuite) TestBadAddOrUpdateSignatures(c *C) {
 	checkSigIDs("root.json")
 }
 
-func (rs *RepoSuite) TestSignDigest(c *C){
+func (rs *RepoSuite) TestSignDigest(c *C) {
 	files := map[string][]byte{"foo.txt": []byte("foo")}
 	local := MemoryStore(make(map[string]json.RawMessage), files)
 	r, err := NewRepo(local)
@@ -1811,7 +1811,7 @@ func (rs *RepoSuite) TestSignDigest(c *C){
 	digest := "sha256:bc11b176a293bb341a0f2d0d226f52e7fcebd186a7c4dfca5fc64f305f06b94c"
 	size := int64(42)
 
-	c.Assert(r.AddDigestTargets(digest, size, nil), IsNil)
+	c.Assert(r.AddDigestTargets(digest, size, nil, ""), IsNil)
 	c.Assert(r.Snapshot(), IsNil)
 	c.Assert(r.Timestamp(), IsNil)
 	c.Assert(r.Commit(), IsNil)
@@ -1821,7 +1821,7 @@ func (rs *RepoSuite) TestSignDigest(c *C){
 	c.Assert(err, IsNil)
 
 	targets, err := r.targets()
-		c.Assert(err, IsNil)
+	c.Assert(err, IsNil)
 	c.Assert(targets.Targets["sha256:bc11b176a293bb341a0f2d0d226f52e7fcebd186a7c4dfca5fc64f305f06b94c"].FileMeta.Length, Equals, size)
 	c.Assert(targets.Targets["sha256:bc11b176a293bb341a0f2d0d226f52e7fcebd186a7c4dfca5fc64f305f06b94c"].FileMeta.Hashes["sha256"], DeepEquals, hex_digest_bytes)
 


### PR DESCRIPTION
Allows users of go-tuf to sign oci images or other non-local targets by directly providing the hash and length of these artifacts. Solves #165

cc @ethan-lowman-dd @trishankatdatadog @sudo-bmitch