### PR TITLE
expose `Close()` in `LocalStore` interface

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -24,6 +24,8 @@ const (
 
 // LocalStore is local storage for downloaded top-level metadata.
 type LocalStore interface {
+	io.Closer
+
 	// GetMeta returns top-level metadata from local storage. The keys are
 	// in the form `ROLE.json`, with ROLE being a valid top-level role.
 	GetMeta() (map[string]json.RawMessage, error)

--- a/client/leveldbstore/leveldbstore_test.go
+++ b/client/leveldbstore/leveldbstore_test.go
@@ -20,6 +20,7 @@ func (LocalStoreSuite) TestFileLocalStore(c *C) {
 	path := filepath.Join(tmp, "tuf.db")
 	store, err := FileLocalStore(path)
 	c.Assert(err, IsNil)
+	defer store.Close()
 
 	type meta map[string]json.RawMessage
 
@@ -43,9 +44,12 @@ func (LocalStoreSuite) TestFileLocalStore(c *C) {
 	assertGet(meta{"root.json": rootJSON, "targets.json": targetsJSON})
 
 	// a new store should get the same meta
-	c.Assert(store.(*fileLocalStore).Close(), IsNil)
+	c.Assert(store.Close(), IsNil)
 	store, err = FileLocalStore(path)
 	c.Assert(err, IsNil)
+	defer func() {
+		c.Assert(store.Close(), IsNil)
+	}()
 	assertGet(meta{"root.json": rootJSON, "targets.json": targetsJSON})
 }
 

--- a/client/local_store.go
+++ b/client/local_store.go
@@ -23,3 +23,7 @@ func (m memoryLocalStore) DeleteMeta(name string) error {
 	delete(m, name)
 	return nil
 }
+
+func (m memoryLocalStore) Close() error {
+	return nil
+}

--- a/client/local_store_test.go
+++ b/client/local_store_test.go
@@ -8,6 +8,9 @@ import (
 
 func TestDeleteMeta(t *testing.T) {
 	l := MemoryLocalStore()
+	defer func() {
+		assert.Equal(t, nil, l.Close())
+	}()
 	assert.Equal(t, l.SetMeta("root.json", []byte(`
   {
 	  "signed": {},


### PR DESCRIPTION
This allows for package consumers to elegantly`Close()` the underlying datastore, avoiding memory leaks.

See also: https://github.com/sigstore/cosign/issues/1160