### PR TITLE
[Delegations prereq 5, reopened] Support delegated targets in DefaultExpires and fix GenKey expiration

### DIFF
--- a/data/types.go
+++ b/data/types.go
@@ -82,12 +82,13 @@ func DefaultExpires(role string) time.Time {
 	switch role {
 	case "root":
 		t = time.Now().AddDate(1, 0, 0)
-	case "targets":
-		t = time.Now().AddDate(0, 3, 0)
 	case "snapshot":
 		t = time.Now().AddDate(0, 0, 7)
 	case "timestamp":
 		t = time.Now().AddDate(0, 0, 1)
+	default:
+		// targets and delegated targets
+		t = time.Now().AddDate(0, 3, 0)
 	}
 	return t.UTC().Round(time.Second)
 }

--- a/repo.go
+++ b/repo.go
@@ -332,7 +332,7 @@ func (r *Repo) ChangePassphrase(keyRole string) error {
 }
 
 func (r *Repo) GenKey(role string) ([]string, error) {
-	return r.GenKeyWithExpires(role, data.DefaultExpires("root"))
+	return r.GenKeyWithExpires(role, data.DefaultExpires(role))
 }
 
 func (r *Repo) GenKeyWithExpires(keyRole string, expires time.Time) (keyids []string, err error) {


### PR DESCRIPTION
This was originally reviewed in #195, but the stacked PR was accidentally merged out of order.