### PR TITLE
Add client method for initializing from root metadata

### DIFF
--- a/client/delegations_test.go
+++ b/client/delegations_test.go
@@ -268,19 +268,7 @@ func initTestDelegationClient(t *testing.T, dirPrefix string) (*Client, func() e
 	c := NewClient(MemoryLocalStore(), remote)
 	rawFile, err := ioutil.ReadFile(initialStateDir + "/" + "root.json")
 	assert.Nil(t, err)
-	s := &data.Signed{}
-	root := &data.Root{}
-	assert.Nil(t, json.Unmarshal(rawFile, s))
-	assert.Nil(t, json.Unmarshal(s.Signed, root))
-	var keys []*data.PublicKey
-	for _, sig := range s.Signatures {
-		k, ok := root.Keys[sig.KeyID]
-		if ok {
-			keys = append(keys, k)
-		}
-	}
-
-	assert.Nil(t, c.Init(keys, 1))
+	assert.Nil(t, c.InitLocal(rawFile))
 	files, err := ioutil.ReadDir(initialStateDir)
 	assert.Nil(t, err)
 

--- a/client/interop_test.go
+++ b/client/interop_test.go
@@ -2,8 +2,8 @@ package client
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"github.com/theupdateframework/go-tuf/data"
 	"github.com/theupdateframework/go-tuf/util"
 	. "gopkg.in/check.v1"
 
@@ -150,9 +149,12 @@ func (t *testCase) runStep(c *C, stepName string) {
 	c.Assert(err, IsNil)
 
 	client := NewClient(t.local, remote)
-	// initiate a client with the root keys
-	keys := getKeys(c, remote)
-	c.Assert(client.Init(keys, 1), IsNil)
+	// initiate a client with the root metadata
+	ioReader, _, err := remote.GetMeta("root.json")
+	c.Assert(err, IsNil)
+	rootJsonBytes, err := io.ReadAll(ioReader)
+	c.Assert(err, IsNil)
+	c.Assert(client.InitLocal(rootJsonBytes), IsNil)
 
 	// check update returns the correct updated targets
 	files, err := client.Update()
@@ -190,32 +192,4 @@ func startFileServer(c *C, dir string) (string, func() error) {
 	addr := l.Addr().String()
 	go http.Serve(l, http.FileServer(http.Dir(dir)))
 	return addr, l.Close
-}
-
-func getKeys(c *C, remote RemoteStore) []*data.PublicKey {
-	r, _, err := remote.GetMeta("root.json")
-	c.Assert(err, IsNil)
-
-	type SignedRoot struct {
-		Signed data.Root
-	}
-	root := &SignedRoot{}
-	err = json.NewDecoder(r).Decode(&root)
-	c.Assert(err, IsNil)
-
-	rootRole, exists := root.Signed.Roles["root"]
-	c.Assert(exists, Equals, true)
-
-	rootKeys := []*data.PublicKey{}
-
-	for _, keyID := range rootRole.KeyIDs {
-		key, exists := root.Signed.Keys[keyID]
-		c.Assert(exists, Equals, true)
-
-		rootKeys = append(rootKeys, key)
-	}
-
-	c.Assert(rootKeys, Not(HasLen), 0)
-
-	return rootKeys
 }

--- a/client/python_interop/python_interop_test.go
+++ b/client/python_interop/python_interop_test.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -14,10 +13,7 @@ import (
 
 	tuf "github.com/theupdateframework/go-tuf"
 	client "github.com/theupdateframework/go-tuf/client"
-	"github.com/theupdateframework/go-tuf/data"
-	"github.com/theupdateframework/go-tuf/pkg/keys"
 	"github.com/theupdateframework/go-tuf/util"
-	"golang.org/x/crypto/ed25519"
 	. "gopkg.in/check.v1"
 )
 
@@ -59,17 +55,11 @@ func (InteropSuite) TestGoClientPythonGenerated(c *C) {
 		)
 		c.Assert(err, IsNil)
 
-		// initiate a client with the root keys
-		f, err := os.Open(filepath.Join(testDataDir, dir, "keystore", "root_key.pub"))
-		c.Assert(err, IsNil)
-		key := &data.PublicKey{}
-		c.Assert(json.NewDecoder(f).Decode(key), IsNil)
-		c.Assert(key.Type, Equals, "ed25519")
-		pk, err := keys.GetVerifier(key)
-		c.Assert(err, IsNil)
-		c.Assert(pk.Public(), HasLen, ed25519.PublicKeySize)
+		// initiate a client with the root metadata
 		client := client.NewClient(client.MemoryLocalStore(), remote)
-		c.Assert(client.Init([]*data.PublicKey{key}, 1), IsNil)
+		rootJSON, err := ioutil.ReadFile(filepath.Join(testDataDir, dir, "repository", "metadata", "root.json"))
+		c.Assert(err, IsNil)
+		c.Assert(client.InitLocal(rootJSON), IsNil)
 
 		// check update returns the correct updated targets
 		files, err := client.Update()

--- a/cmd/tuf-client/init.go
+++ b/cmd/tuf-client/init.go
@@ -1,28 +1,26 @@
 package main
 
 import (
-	"encoding/json"
 	"io"
 	"os"
 
 	"github.com/flynn/go-docopt"
 	tuf "github.com/theupdateframework/go-tuf/client"
-	"github.com/theupdateframework/go-tuf/data"
 )
 
 func init() {
 	register("init", cmdInit, `
-usage: tuf-client init [-s|--store=<path>] <url> [<root-keys-file>]
+usage: tuf-client init [-s|--store=<path>] <url> [<root-metadata-file>]
 
 Options:
   -s <path>    The path to the local file store [default: tuf.db]
 
-Initialize the local file store with root keys.
+Initialize the local file store with root metadata.
   `)
 }
 
 func cmdInit(args *docopt.Args, client *tuf.Client) error {
-	file := args.String["<root-keys-file>"]
+	file := args.String["<root-metadata-file>"]
 	var in io.Reader
 	if file == "" || file == "-" {
 		in = os.Stdin
@@ -33,9 +31,9 @@ func cmdInit(args *docopt.Args, client *tuf.Client) error {
 			return err
 		}
 	}
-	var rootKeys []*data.PublicKey
-	if err := json.NewDecoder(in).Decode(&rootKeys); err != nil {
+	bytes, err := io.ReadAll(in)
+	if err != nil {
 		return err
 	}
-	return client.Init(rootKeys, len(rootKeys))
+	return client.InitLocal(bytes)
 }


### PR DESCRIPTION
This will allow users of go-tuf to initialize a client
without requiring a remote connection. This is useful
for when a root has been updated and the local root
verification keys can no longer verify the the latest
remote root, except by verifying the chain with
client.Update().

Ref #208

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>