### PR TITLE
make ED25519PrivateKeyValue public, add a way to instantiate ed25519Signer from it

### DIFF
--- a/pkg/keys/ed25519.go
+++ b/pkg/keys/ed25519.go
@@ -54,7 +54,7 @@ func (e *ed25519Verifier) UnmarshalPublicKey(key *data.PublicKey) error {
 	return nil
 }
 
-type ed25519PrivateKeyValue struct {
+type ED25519PrivateKeyValue struct {
 	Public  data.HexBytes `json:"public"`
 	Private data.HexBytes `json:"private"`
 }
@@ -88,7 +88,7 @@ func (e *ed25519Signer) SignMessage(message []byte) ([]byte, error) {
 }
 
 func (e *ed25519Signer) MarshalPrivateKey() (*data.PrivateKey, error) {
-	valueBytes, err := json.Marshal(ed25519PrivateKeyValue{
+	valueBytes, err := json.Marshal(ED25519PrivateKeyValue{
 		Public:  data.HexBytes([]byte(e.PrivateKey.Public().(ed25519.PublicKey))),
 		Private: data.HexBytes(e.PrivateKey),
 	})
@@ -104,7 +104,7 @@ func (e *ed25519Signer) MarshalPrivateKey() (*data.PrivateKey, error) {
 }
 
 func (e *ed25519Signer) UnmarshalPrivateKey(key *data.PrivateKey) error {
-	keyValue := &ed25519PrivateKeyValue{}
+	keyValue := &ED25519PrivateKeyValue{}
 	if err := json.Unmarshal(key.Value, keyValue); err != nil {
 		return err
 	}

--- a/pkg/keys/ed25519.go
+++ b/pkg/keys/ed25519.go
@@ -54,7 +54,7 @@ func (e *ed25519Verifier) UnmarshalPublicKey(key *data.PublicKey) error {
 	return nil
 }
 
-type ED25519PrivateKeyValue struct {
+type Ed25519PrivateKeyValue struct {
 	Public  data.HexBytes `json:"public"`
 	Private data.HexBytes `json:"private"`
 }
@@ -83,12 +83,21 @@ func GenerateEd25519Key() (*ed25519Signer, error) {
 	}, nil
 }
 
+func Ed25519Key(keyValue Ed25519PrivateKeyValue) *ed25519Signer {
+	return &ed25519Signer{
+		PrivateKey:    ed25519.PrivateKey(data.HexBytes(keyValue.Private)),
+		keyType:       data.KeyTypeEd25519,
+		keyScheme:     data.KeySchemeEd25519,
+		keyAlgorithms: data.HashAlgorithms,
+	}
+}
+
 func (e *ed25519Signer) SignMessage(message []byte) ([]byte, error) {
 	return e.Sign(rand.Reader, message, crypto.Hash(0))
 }
 
 func (e *ed25519Signer) MarshalPrivateKey() (*data.PrivateKey, error) {
-	valueBytes, err := json.Marshal(ED25519PrivateKeyValue{
+	valueBytes, err := json.Marshal(Ed25519PrivateKeyValue{
 		Public:  data.HexBytes([]byte(e.PrivateKey.Public().(ed25519.PublicKey))),
 		Private: data.HexBytes(e.PrivateKey),
 	})
@@ -104,7 +113,7 @@ func (e *ed25519Signer) MarshalPrivateKey() (*data.PrivateKey, error) {
 }
 
 func (e *ed25519Signer) UnmarshalPrivateKey(key *data.PrivateKey) error {
-	keyValue := &ED25519PrivateKeyValue{}
+	keyValue := &Ed25519PrivateKeyValue{}
 	if err := json.Unmarshal(key.Value, keyValue); err != nil {
 		return err
 	}

--- a/pkg/keys/ed25519.go
+++ b/pkg/keys/ed25519.go
@@ -83,7 +83,7 @@ func GenerateEd25519Key() (*ed25519Signer, error) {
 	}, nil
 }
 
-func Ed25519Key(keyValue Ed25519PrivateKeyValue) *ed25519Signer {
+func NewEd25519Signer(keyValue Ed25519PrivateKeyValue) *ed25519Signer {
 	return &ed25519Signer{
 		PrivateKey:    ed25519.PrivateKey(data.HexBytes(keyValue.Private)),
 		keyType:       data.KeyTypeEd25519,


### PR DESCRIPTION
# What does this PR do ?

1. Makes `Ed25519PrivateKeyValue` public
2. Adds a way to instantiate ed25519Signer from `Ed25519PrivateKeyValue`

With the change of interface for the keys there is no non-hacky way to use an ed25519 key that is not stored as a `go-tuf` specific marshaled JSON blob without re-implementing the signer interface.