### PR TITLE
Rename assertNotNil to assertNoError, since the former name is incorrect

### DIFF
--- a/client/testdata/go-tuf-transition-M3/generate.go
+++ b/client/testdata/go-tuf-transition-M3/generate.go
@@ -22,7 +22,7 @@ type persistedKeys struct {
 	Data      []*data.PrivateKey `json:"data"`
 }
 
-func assertNotNil(err error) {
+func assertNoError(err error) {
 	if err != nil {
 		panic(fmt.Sprintf("assertion failed: %s", err))
 	}
@@ -30,31 +30,31 @@ func assertNotNil(err error) {
 
 func copyRepo(src string, dst string) {
 	cmd := exec.Command("cp", "-r", src, dst)
-	assertNotNil(cmd.Run())
+	assertNoError(cmd.Run())
 }
 
 func newRepo(dir string) *tuf.Repo {
 	repo, err := tuf.NewRepoIndent(tuf.FileSystemStore(dir, nil), "", "\t")
-	assertNotNil(err)
+	assertNoError(err)
 
 	return repo
 }
 
 func commit(dir string, repo *tuf.Repo) {
-	assertNotNil(repo.SnapshotWithExpires(expirationDate))
-	assertNotNil(repo.TimestampWithExpires(expirationDate))
-	assertNotNil(repo.Commit())
+	assertNoError(repo.SnapshotWithExpires(expirationDate))
+	assertNoError(repo.TimestampWithExpires(expirationDate))
+	assertNoError(repo.Commit())
 
 	// Remove the keys directory to make sure we don't accidentally use a key.
-	assertNotNil(os.RemoveAll(filepath.Join(dir, "keys")))
+	assertNoError(os.RemoveAll(filepath.Join(dir, "keys")))
 }
 
 func addKeys(repo *tuf.Repo, roleKeys map[string][]*data.PrivateKey) {
 	for role, keyList := range roleKeys {
 		for _, key := range keyList {
 			signer, err := keys.GetSigner(key)
-			assertNotNil(err)
-			assertNotNil(repo.AddPrivateKeyWithExpires(role, signer, expirationDate))
+			assertNoError(err)
+			assertNoError(repo.AddPrivateKeyWithExpires(role, signer, expirationDate))
 		}
 	}
 }
@@ -63,27 +63,27 @@ func addTargets(repo *tuf.Repo, dir string, files map[string][]byte) {
 	paths := []string{}
 	for file, data := range files {
 		path := filepath.Join(dir, "staged", "targets", file)
-		assertNotNil(os.MkdirAll(filepath.Dir(path), 0755))
-		assertNotNil(ioutil.WriteFile(path, data, 0644))
+		assertNoError(os.MkdirAll(filepath.Dir(path), 0755))
+		assertNoError(ioutil.WriteFile(path, data, 0644))
 		paths = append(paths, file)
 	}
-	assertNotNil(repo.AddTargetsWithExpires(paths, nil, expirationDate))
+	assertNoError(repo.AddTargetsWithExpires(paths, nil, expirationDate))
 }
 
 func revokeKeys(repo *tuf.Repo, role string, keyList []*data.PrivateKey) {
 	for _, key := range keyList {
 		signer, err := keys.GetSigner(key)
-		assertNotNil(err)
-		assertNotNil(repo.RevokeKeyWithExpires(role, signer.PublicData().IDs()[0], expirationDate))
+		assertNoError(err)
+		assertNoError(repo.RevokeKeyWithExpires(role, signer.PublicData().IDs()[0], expirationDate))
 	}
 }
 
 func generateRepos(dir string, consistentSnapshot bool) {
 	f, err := os.Open("../keys.json")
-	assertNotNil(err)
+	assertNoError(err)
 
 	var roleKeys map[string][][]*data.PrivateKey
-	assertNotNil(json.NewDecoder(f).Decode(&roleKeys))
+	assertNoError(json.NewDecoder(f).Decode(&roleKeys))
 
 	// Collect all the initial keys we'll use when creating repositories.
 	// We'll modify this to reflect rotated keys.
@@ -140,7 +140,7 @@ func generateRepos(dir string, consistentSnapshot bool) {
 
 func main() {
 	cwd, err := os.Getwd()
-	assertNotNil(err)
+	assertNoError(err)
 
 	for _, consistentSnapshot := range []bool{false, true} {
 		name := fmt.Sprintf("consistent-snapshot-%t", consistentSnapshot)

--- a/client/testdata/go-tuf-transition-M4/generate.go
+++ b/client/testdata/go-tuf-transition-M4/generate.go
@@ -22,7 +22,7 @@ type persistedKeys struct {
 	Data      []*data.PrivateKey `json:"data"`
 }
 
-func assertNotNil(err error) {
+func assertNoError(err error) {
 	if err != nil {
 		panic(fmt.Sprintf("assertion failed: %s", err))
 	}
@@ -30,29 +30,29 @@ func assertNotNil(err error) {
 
 func copyRepo(src string, dst string) {
 	cmd := exec.Command("cp", "-r", src, dst)
-	assertNotNil(cmd.Run())
+	assertNoError(cmd.Run())
 }
 
 func newRepo(dir string) *tuf.Repo {
 	repo, err := tuf.NewRepoIndent(tuf.FileSystemStore(dir, nil), "", "\t")
-	assertNotNil(err)
+	assertNoError(err)
 
 	return repo
 }
 
 func commit(dir string, repo *tuf.Repo) {
-	assertNotNil(repo.SnapshotWithExpires(expirationDate))
-	assertNotNil(repo.TimestampWithExpires(expirationDate))
-	assertNotNil(repo.Commit())
+	assertNoError(repo.SnapshotWithExpires(expirationDate))
+	assertNoError(repo.TimestampWithExpires(expirationDate))
+	assertNoError(repo.Commit())
 
 	// Remove the keys directory to make sure we don't accidentally use a key.
-	assertNotNil(os.RemoveAll(filepath.Join(dir, "keys")))
+	assertNoError(os.RemoveAll(filepath.Join(dir, "keys")))
 }
 
 func addKeys(repo *tuf.Repo, roleKeys map[string][]*data.PrivateKey) {
 	for role, keys := range roleKeys {
 		for _, key := range keys {
-			assertNotNil(repo.AddPrivateKeyWithExpires(role, key, expirationDate))
+			assertNoError(repo.AddPrivateKeyWithExpires(role, key, expirationDate))
 		}
 	}
 }
@@ -61,27 +61,27 @@ func addTargets(repo *tuf.Repo, dir string, files map[string][]byte) {
 	paths := []string{}
 	for file, data := range files {
 		path := filepath.Join(dir, "staged", "targets", file)
-		assertNotNil(os.MkdirAll(filepath.Dir(path), 0755))
-		assertNotNil(ioutil.WriteFile(path, data, 0644))
+		assertNoError(os.MkdirAll(filepath.Dir(path), 0755))
+		assertNoError(ioutil.WriteFile(path, data, 0644))
 		paths = append(paths, file)
 	}
-	assertNotNil(repo.AddTargetsWithExpires(paths, nil, expirationDate))
+	assertNoError(repo.AddTargetsWithExpires(paths, nil, expirationDate))
 }
 
 func revokeKeys(repo *tuf.Repo, role string, keyList []*data.PrivateKey) {
 	for _, key := range keyList {
 		signer, err := keys.GetSigner(key)
-		assertNotNil(err)
-		assertNotNil(repo.RevokeKeyWithExpires(role, signer.PublicData().IDs()[0], expirationDate))
+		assertNoError(err)
+		assertNoError(repo.RevokeKeyWithExpires(role, signer.PublicData().IDs()[0], expirationDate))
 	}
 }
 
 func generateRepos(dir string, consistentSnapshot bool) {
 	f, err := os.Open("../keys.json")
-	assertNotNil(err)
+	assertNoError(err)
 
 	var roleKeys map[string][][]*data.PrivateKey
-	assertNotNil(json.NewDecoder(f).Decode(&roleKeys))
+	assertNoError(json.NewDecoder(f).Decode(&roleKeys))
 
 	// Collect all the initial keys we'll use when creating repositories.
 	// We'll modify this to reflect rotated keys.
@@ -138,7 +138,7 @@ func generateRepos(dir string, consistentSnapshot bool) {
 
 func main() {
 	cwd, err := os.Getwd()
-	assertNotNil(err)
+	assertNoError(err)
 
 	for _, consistentSnapshot := range []bool{false, true} {
 		name := fmt.Sprintf("consistent-snapshot-%t", consistentSnapshot)

--- a/client/testdata/go-tuf/generator/generator.go
+++ b/client/testdata/go-tuf/generator/generator.go
@@ -22,7 +22,7 @@ type persistedKeys struct {
 	Data      []*data.PrivateKey `json:"data"`
 }
 
-func assertNotNil(err error) {
+func assertNoError(err error) {
 	if err != nil {
 		panic(fmt.Sprintf("assertion failed: %s", err))
 	}
@@ -30,31 +30,31 @@ func assertNotNil(err error) {
 
 func copyRepo(src string, dst string) {
 	cmd := exec.Command("cp", "-r", src, dst)
-	assertNotNil(cmd.Run())
+	assertNoError(cmd.Run())
 }
 
 func newRepo(dir string) *tuf.Repo {
 	repo, err := tuf.NewRepoIndent(tuf.FileSystemStore(dir, nil), "", "\t")
-	assertNotNil(err)
+	assertNoError(err)
 
 	return repo
 }
 
 func commit(dir string, repo *tuf.Repo) {
-	assertNotNil(repo.SnapshotWithExpires(expirationDate))
-	assertNotNil(repo.TimestampWithExpires(expirationDate))
-	assertNotNil(repo.Commit())
+	assertNoError(repo.SnapshotWithExpires(expirationDate))
+	assertNoError(repo.TimestampWithExpires(expirationDate))
+	assertNoError(repo.Commit())
 
 	// Remove the keys directory to make sure we don't accidentally use a key.
-	assertNotNil(os.RemoveAll(filepath.Join(dir, "keys")))
+	assertNoError(os.RemoveAll(filepath.Join(dir, "keys")))
 }
 
 func addKeys(repo *tuf.Repo, roleKeys map[string][]*data.PrivateKey) {
 	for role, keyList := range roleKeys {
 		for _, key := range keyList {
 			signer, err := keys.GetSigner(key)
-			assertNotNil(err)
-			assertNotNil(repo.AddPrivateKeyWithExpires(role, signer, expirationDate))
+			assertNoError(err)
+			assertNoError(repo.AddPrivateKeyWithExpires(role, signer, expirationDate))
 		}
 	}
 }
@@ -63,18 +63,18 @@ func addTargets(repo *tuf.Repo, dir string, files map[string][]byte) {
 	paths := []string{}
 	for file, data := range files {
 		path := filepath.Join(dir, "staged", "targets", file)
-		assertNotNil(os.MkdirAll(filepath.Dir(path), 0755))
-		assertNotNil(ioutil.WriteFile(path, data, 0644))
+		assertNoError(os.MkdirAll(filepath.Dir(path), 0755))
+		assertNoError(ioutil.WriteFile(path, data, 0644))
 		paths = append(paths, file)
 	}
-	assertNotNil(repo.AddTargetsWithExpires(paths, nil, expirationDate))
+	assertNoError(repo.AddTargetsWithExpires(paths, nil, expirationDate))
 }
 
 func revokeKeys(repo *tuf.Repo, role string, keyList []*data.PrivateKey) {
 	for _, key := range keyList {
 		signer, err := keys.GetSigner(key)
-		assertNotNil(err)
-		assertNotNil(repo.RevokeKeyWithExpires(role, signer.PublicData().IDs()[0], expirationDate))
+		assertNoError(err)
+		assertNoError(repo.RevokeKeyWithExpires(role, signer.PublicData().IDs()[0], expirationDate))
 	}
 }
 
@@ -134,10 +134,10 @@ func generateRepos(dir string, roleKeys map[string][][]*data.PrivateKey, consist
 
 func Generate(dir string, keysPath string, consistentSnapshot bool) {
 	f, err := os.Open(keysPath)
-	assertNotNil(err)
+	assertNoError(err)
 
 	var roleKeys map[string][][]*data.PrivateKey
-	assertNotNil(json.NewDecoder(f).Decode(&roleKeys))
+	assertNoError(json.NewDecoder(f).Decode(&roleKeys))
 
 	log.Printf("generating %s", dir)
 

--- a/client/testdata/tools/gen-keys.go
+++ b/client/testdata/tools/gen-keys.go
@@ -30,7 +30,7 @@ func main() {
 
 		for i := 0; i < 2; i++ {
 			signer, err := keys.GenerateEd25519Key()
-			assertNotNil(err)
+			assertNoError(err)
 			keys = append(keys, []*data.PrivateKey{signer})
 		}
 
@@ -38,12 +38,12 @@ func main() {
 	}
 
 	s, err := json.MarshalIndent(&roles, "", "    ")
-	assertNotNil(err)
+	assertNoError(err)
 
 	ioutil.WriteFile("keys.json", []byte(s), 0644)
 }
 
-func assertNotNil(err error) {
+func assertNoError(err error) {
 	if err != nil {
 		panic(fmt.Sprintf("assertion failed: %s", err))
 	}


### PR DESCRIPTION
The `assertNotNil` helper functions were actually asserting that the error *was* nil. This PR renames the functions to reflect their actual behavior.