### PR TITLE
Fix linter errors raised by staticcheck

### DIFF
--- a/local_store.go
+++ b/local_store.go
@@ -431,11 +431,9 @@ func (f *fileSystemStore) Commit(consistentSnapshot bool, versions map[string]in
 			return err
 		}
 		if !info.IsDir() && isTarget(rel) && needsRemoval(rel) {
-			//lint:ignore SA9003 empty branch
 			if err := os.Remove(path); err != nil {
-				// TODO: log / handle error
+				return err
 			}
-			// TODO: remove empty directory
 		}
 		return nil
 	}

--- a/local_store.go
+++ b/local_store.go
@@ -431,10 +431,7 @@ func (f *fileSystemStore) Commit(consistentSnapshot bool, versions map[string]in
 		}
 		defer f.Close()
 		_, err = f.Readdirnames(1)
-		if err == io.EOF {
-			return true
-		}
-		return false
+		return err == io.EOF
 	}
 	removeFile := func(path string, info os.FileInfo, err error) error {
 		if err != nil {

--- a/repo_test.go
+++ b/repo_test.go
@@ -1477,7 +1477,7 @@ func (rs *RepoSuite) TestManageMultipleTargets(c *C) {
 	c.Assert(r.Snapshot(), IsNil)
 	c.Assert(r.Timestamp(), IsNil)
 	c.Assert(r.Commit(), IsNil)
-	tmp.assertEmpty("repository/targets")
+	tmp.assertNotExist("repository/targets")
 	t, err := r.topLevelTargets()
 	c.Assert(err, IsNil)
 	c.Assert(t.Targets, HasLen, 0)

--- a/verify/db_test.go
+++ b/verify/db_test.go
@@ -36,7 +36,7 @@ func TestDelegationsDB(t *testing.T) {
 		{
 			testName: "invalid keys",
 			delegations: &data.Delegations{Keys: map[string]*data.PublicKey{
-				"a": &data.PublicKey{Type: data.KeySchemeEd25519},
+				"a": {Type: data.KeySchemeEd25519},
 			}},
 			initErr: ErrWrongID{},
 		},


### PR DESCRIPTION
This is a small PR separating a few fixes for linter errors that would otherwise be raised by golangci-lint/staticcheck in #234. 

Signed-off-by: Radoslav Dimitrov <dimitrovr@vmware.com>