### PR TITLE
Allow commit without adding targets

### DIFF
--- a/repo.go
+++ b/repo.go
@@ -112,11 +112,14 @@ func (r *Repo) Init(consistentSnapshot bool) error {
 	root.ConsistentSnapshot = consistentSnapshot
 	// Set root version to 1 for a new root.
 	root.Version = 1
-	err = r.setTopLevelMeta("root.json", root)
-	if err == nil {
-		fmt.Println("Repository initialized")
+	if err = r.setTopLevelMeta("root.json", root); err != nil {
+		return err
 	}
-	return err
+	if err = r.writeTargetWithExpires(t, data.DefaultExpires("targets")); err != nil {
+		return err
+	}
+	fmt.Println("Repository initialized")
+	return nil
 }
 
 func (r *Repo) topLevelKeysDB() (*verify.DB, error) {
@@ -776,7 +779,7 @@ func (r *Repo) writeTargetWithExpires(t *data.Targets, expires time.Time) error 
 	}
 
 	err := r.setTopLevelMeta("targets.json", t)
-	if err == nil {
+	if err == nil && len(t.Targets) > 0 {
 		fmt.Println("Added/staged targets:")
 		for k := range t.Targets {
 			fmt.Println("*", k)

--- a/repo_test.go
+++ b/repo_test.go
@@ -687,13 +687,15 @@ func (rs *RepoSuite) TestCommit(c *C) {
 	// commit without root.json
 	c.Assert(r.Commit(), DeepEquals, ErrMissingMetadata{"root.json"})
 
-	// commit without targets.json
+	// Init should create targets.json, but not signed yet
+	r.Init(false)
+	c.Assert(r.Commit(), DeepEquals, ErrMissingMetadata{"snapshot.json"})
+
 	genKey(c, r, "root")
-	c.Assert(r.Commit(), DeepEquals, ErrMissingMetadata{"targets.json"})
 
 	// commit without snapshot.json
 	genKey(c, r, "targets")
-	c.Assert(r.AddTarget("foo.txt", nil), IsNil)
+	c.Assert(r.Sign("targets.json"), IsNil)
 	c.Assert(r.Commit(), DeepEquals, ErrMissingMetadata{"snapshot.json"})
 
 	// commit without timestamp.json
@@ -714,12 +716,12 @@ func (rs *RepoSuite) TestCommit(c *C) {
 	// commit with an invalid root hash in snapshot.json due to new key creation
 	genKey(c, r, "targets")
 	c.Assert(r.Sign("targets.json"), IsNil)
-	c.Assert(r.Commit(), DeepEquals, errors.New("tuf: invalid targets.json in snapshot.json: wrong length, expected 511 got 725"))
+	c.Assert(r.Commit(), DeepEquals, errors.New("tuf: invalid targets.json in snapshot.json: wrong length, expected 338 got 552"))
 
 	// commit with an invalid targets hash in snapshot.json
 	c.Assert(r.Snapshot(), IsNil)
 	c.Assert(r.AddTarget("bar.txt", nil), IsNil)
-	c.Assert(r.Commit(), DeepEquals, errors.New("tuf: invalid targets.json in snapshot.json: wrong length, expected 725 got 899"))
+	c.Assert(r.Commit(), DeepEquals, errors.New("tuf: invalid targets.json in snapshot.json: wrong length, expected 552 got 725"))
 
 	// commit with an invalid timestamp
 	c.Assert(r.Snapshot(), IsNil)


### PR DESCRIPTION
By making `init` write an empty `targets.json`.

The following didn't work before but now does:

```shell
tuf init

tuf gen-key root
tuf gen-key targets
tuf gen-key snapshot
tuf gen-key timestamp

tuf sign root.json
# you used to need a `tuf add` here
tuf sign targets.json

tuf snapshot
tuf timestamp

tuf commit
```
