### PR TITLE
use int64 instead of int for metadata version

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -69,10 +69,10 @@ type Client struct {
 
 	// The following four fields represent the versions of metatdata either
 	// from local storage or from recently downloaded metadata
-	rootVer      int
-	targetsVer   int
-	snapshotVer  int
-	timestampVer int
+	rootVer      int64
+	targetsVer   int64
+	snapshotVer  int64
+	timestampVer int64
 
 	// targets is the list of available targets, either from local storage
 	// or from recently downloaded targets metadata
@@ -612,7 +612,7 @@ func (c *Client) downloadTarget(file string, get remoteGetFunc, hashes data.Hash
 
 // downloadVersionedMeta downloads top-level metadata from remote storage and
 // verifies it using the given file metadata.
-func (c *Client) downloadMeta(name string, version int, m data.FileMeta) ([]byte, error) {
+func (c *Client) downloadMeta(name string, version int64, m data.FileMeta) ([]byte, error) {
 	r, size, err := func() (io.ReadCloser, int64, error) {
 		if c.consistentSnapshot {
 			path := util.VersionedPath(name, version)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -456,39 +456,39 @@ func (s *ClientSuite) TestUpdateRoots(c *C) {
 	var tests = []struct {
 		fixturePath      string
 		expectedError    error
-		expectedVersions map[string]int
+		expectedVersions map[string]int64
 	}{
 		// Succeeds when there is no root update.
-		{"testdata/Published1Time", nil, map[string]int{"root": 1, "timestamp": 1, "snapshot": 1, "targets": 1}},
+		{"testdata/Published1Time", nil, map[string]int64{"root": 1, "timestamp": 1, "snapshot": 1, "targets": 1}},
 		// Succeeds when client only has root.json
-		{"testdata/Published1Time_client_root_only", nil, map[string]int{"root": 1, "timestamp": 1, "snapshot": 1, "targets": 1}},
+		{"testdata/Published1Time_client_root_only", nil, map[string]int64{"root": 1, "timestamp": 1, "snapshot": 1, "targets": 1}},
 		// Succeeds updating root from version 1 to version 2.
-		{"testdata/Published2Times_keyrotated", nil, map[string]int{"root": 2, "timestamp": 1, "snapshot": 1, "targets": 1}},
+		{"testdata/Published2Times_keyrotated", nil, map[string]int64{"root": 2, "timestamp": 1, "snapshot": 1, "targets": 1}},
 		// Succeeds updating root from version 1 to version 2 when the client's initial root version is expired.
-		{"testdata/Published2Times_keyrotated_initialrootexpired", nil, map[string]int{"root": 2, "timestamp": 1, "snapshot": 1, "targets": 1}},
+		{"testdata/Published2Times_keyrotated_initialrootexpired", nil, map[string]int64{"root": 2, "timestamp": 1, "snapshot": 1, "targets": 1}},
 		// Succeeds updating root from version 1 to version 3 when versions 1 and 2 are expired.
-		{"testdata/Published3Times_keyrotated_initialrootsexpired", nil, map[string]int{"root": 3, "timestamp": 1, "snapshot": 1, "targets": 1}},
+		{"testdata/Published3Times_keyrotated_initialrootsexpired", nil, map[string]int64{"root": 3, "timestamp": 1, "snapshot": 1, "targets": 1}},
 		// Succeeds updating root from version 2 to version 3.
-		{"testdata/Published3Times_keyrotated_initialrootsexpired_clientversionis2", nil, map[string]int{"root": 3, "timestamp": 1, "snapshot": 1, "targets": 1}},
+		{"testdata/Published3Times_keyrotated_initialrootsexpired_clientversionis2", nil, map[string]int64{"root": 3, "timestamp": 1, "snapshot": 1, "targets": 1}},
 		// Fails updating root from version 1 to version 3 when versions 1 and 3 are expired but version 2 is not expired.
-		{"testdata/Published3Times_keyrotated_latestrootexpired", ErrDecodeFailed{File: "root.json", Err: verify.ErrExpired{}}, map[string]int{"root": 2, "timestamp": 1, "snapshot": 1, "targets": 1}},
+		{"testdata/Published3Times_keyrotated_latestrootexpired", ErrDecodeFailed{File: "root.json", Err: verify.ErrExpired{}}, map[string]int64{"root": 2, "timestamp": 1, "snapshot": 1, "targets": 1}},
 		// Fails updating root from version 1 to version 2 when old root 1 did not sign off on it (nth root didn't sign off n+1).
-		{"testdata/Published2Times_keyrotated_invalidOldRootSignature", errors.New("tuf: signature verification failed"), map[string]int{}},
+		{"testdata/Published2Times_keyrotated_invalidOldRootSignature", errors.New("tuf: signature verification failed"), map[string]int64{}},
 		// Fails updating root from version 1 to version 2 when the new root 2 did not sign itself (n+1th root didn't sign off n+1)
-		{"testdata/Published2Times_keyrotated_invalidNewRootSignature", errors.New("tuf: signature verification failed"), map[string]int{}},
+		{"testdata/Published2Times_keyrotated_invalidNewRootSignature", errors.New("tuf: signature verification failed"), map[string]int64{}},
 		// Fails updating root to 2.root.json when the value of the version field inside it is 1 (rollback attack prevention).
-		{"testdata/Published1Time_backwardRootVersion", verify.ErrWrongVersion(verify.ErrWrongVersion{Given: 1, Expected: 2}), map[string]int{}},
+		{"testdata/Published1Time_backwardRootVersion", verify.ErrWrongVersion(verify.ErrWrongVersion{Given: 1, Expected: 2}), map[string]int64{}},
 		// Fails updating root to 2.root.json when the value of the version field inside it is 3 (rollforward attack prevention).
-		{"testdata/Published3Times_keyrotated_forwardRootVersion", verify.ErrWrongVersion(verify.ErrWrongVersion{Given: 3, Expected: 2}), map[string]int{}},
+		{"testdata/Published3Times_keyrotated_forwardRootVersion", verify.ErrWrongVersion(verify.ErrWrongVersion{Given: 3, Expected: 2}), map[string]int64{}},
 		// Fails updating when there is no local trusted root.
-		{"testdata/Published1Time_client_no_root", errors.New("tuf: no root keys found in local meta store"), map[string]int{}},
+		{"testdata/Published1Time_client_no_root", errors.New("tuf: no root keys found in local meta store"), map[string]int64{}},
 
 		// snapshot role key rotation increase the snapshot and timestamp.
-		{"testdata/Published2Times_snapshot_keyrotated", nil, map[string]int{"root": 2, "timestamp": 2, "snapshot": 2, "targets": 1}},
+		{"testdata/Published2Times_snapshot_keyrotated", nil, map[string]int64{"root": 2, "timestamp": 2, "snapshot": 2, "targets": 1}},
 		// targets role key rotation increase the snapshot, timestamp, and targets.
-		{"testdata/Published2Times_targets_keyrotated", nil, map[string]int{"root": 2, "timestamp": 2, "snapshot": 2, "targets": 2}},
+		{"testdata/Published2Times_targets_keyrotated", nil, map[string]int64{"root": 2, "timestamp": 2, "snapshot": 2, "targets": 2}},
 		// timestamp role key rotation increase the timestamp.
-		{"testdata/Published2Times_timestamp_keyrotated", nil, map[string]int{"root": 2, "timestamp": 2, "snapshot": 1, "targets": 1}},
+		{"testdata/Published2Times_timestamp_keyrotated", nil, map[string]int64{"root": 2, "timestamp": 2, "snapshot": 1, "targets": 1}},
 	}
 
 	for _, test := range tests {
@@ -498,7 +498,7 @@ func (s *ClientSuite) TestUpdateRoots(c *C) {
 			c.Assert(err, IsNil)
 			// Check if the root.json is being saved in non-volatile storage.
 			tufClient.getLocalMeta()
-			versionMethods := map[string]int{"root": tufClient.rootVer,
+			versionMethods := map[string]int64{"root": tufClient.rootVer,
 				"timestamp": tufClient.timestampVer,
 				"snapshot":  tufClient.snapshotVer,
 				"targets":   tufClient.targetsVer}
@@ -800,7 +800,7 @@ func (s *ClientSuite) TestUpdateLocalRootExpired(c *C) {
 	c.Assert(s.repo.Commit(), IsNil)
 	s.syncRemote(c)
 
-	const expectedRootVersion = 3
+	const expectedRootVersion = int64(3)
 
 	// check the update downloads the non expired remote root.json and
 	// restarts itself, thus successfully updating

--- a/client/delegations_test.go
+++ b/client/delegations_test.go
@@ -129,7 +129,7 @@ func TestPersistedMeta(t *testing.T) {
 
 	type expectedTargets struct {
 		name    string
-		version int
+		version int64
 	}
 	var persistedTests = []struct {
 		file          string
@@ -241,7 +241,7 @@ func TestPersistedMeta(t *testing.T) {
 	}
 }
 
-func versionOfStoredTargets(name string, store map[string]json.RawMessage) (int, error) {
+func versionOfStoredTargets(name string, store map[string]json.RawMessage) (int64, error) {
 	rawTargets, ok := store[name]
 	if !ok {
 		return 0, nil

--- a/client/errors.go
+++ b/client/errors.go
@@ -42,7 +42,7 @@ func (e ErrDecodeFailed) Error() string {
 type ErrMaxDelegations struct {
 	Target          string
 	MaxDelegations  int
-	SnapshotVersion int
+	SnapshotVersion int64
 }
 
 func (e ErrMaxDelegations) Error() string {
@@ -87,7 +87,7 @@ func (e ErrWrongSize) Error() string {
 }
 
 type ErrLatestSnapshot struct {
-	Version int
+	Version int64
 }
 
 func (e ErrLatestSnapshot) Error() string {
@@ -101,7 +101,7 @@ func IsLatestSnapshot(err error) bool {
 
 type ErrUnknownTarget struct {
 	Name            string
-	SnapshotVersion int
+	SnapshotVersion int64
 }
 
 func (e ErrUnknownTarget) Error() string {
@@ -128,7 +128,7 @@ func (e ErrInvalidURL) Error() string {
 
 type ErrRoleNotInSnapshot struct {
 	Role            string
-	SnapshotVersion int
+	SnapshotVersion int64
 }
 
 func (e ErrRoleNotInSnapshot) Error() string {

--- a/data/types.go
+++ b/data/types.go
@@ -96,7 +96,7 @@ func DefaultExpires(role string) time.Time {
 type Root struct {
 	Type        string                `json:"_type"`
 	SpecVersion string                `json:"spec_version"`
-	Version     int                   `json:"version"`
+	Version     int64                 `json:"version"`
 	Expires     time.Time             `json:"expires"`
 	Keys        map[string]*PublicKey `json:"keys"`
 	Roles       map[string]*Role      `json:"roles"`
@@ -167,7 +167,7 @@ func (f FileMeta) HashAlgorithms() []string {
 
 type SnapshotFileMeta struct {
 	FileMeta
-	Version int `json:"version"`
+	Version int64 `json:"version"`
 }
 
 type SnapshotFiles map[string]SnapshotFileMeta
@@ -175,7 +175,7 @@ type SnapshotFiles map[string]SnapshotFileMeta
 type Snapshot struct {
 	Type        string           `json:"_type"`
 	SpecVersion string           `json:"spec_version"`
-	Version     int              `json:"version"`
+	Version     int64            `json:"version"`
 	Expires     time.Time        `json:"expires"`
 	Meta        SnapshotFiles    `json:"meta"`
 	Custom      *json.RawMessage `json:"custom,omitempty"`
@@ -203,7 +203,7 @@ func (f TargetFileMeta) HashAlgorithms() []string {
 type Targets struct {
 	Type        string           `json:"_type"`
 	SpecVersion string           `json:"spec_version"`
-	Version     int              `json:"version"`
+	Version     int64            `json:"version"`
 	Expires     time.Time        `json:"expires"`
 	Targets     TargetFiles      `json:"targets"`
 	Delegations *Delegations     `json:"delegations,omitempty"`
@@ -302,7 +302,7 @@ func NewTargets() *Targets {
 
 type TimestampFileMeta struct {
 	FileMeta
-	Version int `json:"version"`
+	Version int64 `json:"version"`
 }
 
 type TimestampFiles map[string]TimestampFileMeta
@@ -310,7 +310,7 @@ type TimestampFiles map[string]TimestampFileMeta
 type Timestamp struct {
 	Type        string           `json:"_type"`
 	SpecVersion string           `json:"spec_version"`
-	Version     int              `json:"version"`
+	Version     int64            `json:"version"`
 	Expires     time.Time        `json:"expires"`
 	Meta        TimestampFiles   `json:"meta"`
 	Custom      *json.RawMessage `json:"custom,omitempty"`

--- a/local_store.go
+++ b/local_store.go
@@ -40,7 +40,7 @@ type LocalStore interface {
 	// This will also reset the staged meta to signal incrementing version numbers.
 	// TUF 1.0 requires that the root metadata version numbers in the repository does not
 	// gaps. To avoid this, we will only increment the number once until we commit.
-	Commit(bool, map[string]int, map[string]data.Hashes) error
+	Commit(bool, map[string]int64, map[string]data.Hashes) error
 
 	// GetSigners return a list of signers for a role.
 	GetSigners(role string) ([]keys.Signer, error)
@@ -125,7 +125,7 @@ func (m *memoryStore) WalkStagedTargets(paths []string, targetsFn TargetsWalkFun
 	return nil
 }
 
-func (m *memoryStore) Commit(consistentSnapshot bool, versions map[string]int, hashes map[string]data.Hashes) error {
+func (m *memoryStore) Commit(consistentSnapshot bool, versions map[string]int64, hashes map[string]data.Hashes) error {
 	for name, meta := range m.stagedMeta {
 		paths := computeMetadataPaths(consistentSnapshot, name, versions)
 		for _, path := range paths {
@@ -369,7 +369,7 @@ func (f *fileSystemStore) createRepoFile(path string) (*os.File, error) {
 	return os.Create(dst)
 }
 
-func (f *fileSystemStore) Commit(consistentSnapshot bool, versions map[string]int, hashes map[string]data.Hashes) error {
+func (f *fileSystemStore) Commit(consistentSnapshot bool, versions map[string]int64, hashes map[string]data.Hashes) error {
 	isTarget := func(path string) bool {
 		return strings.HasPrefix(path, "targets/")
 	}
@@ -683,7 +683,7 @@ func computeTargetPaths(consistentSnapshot bool, name string, hashes map[string]
 	}
 }
 
-func computeMetadataPaths(consistentSnapshot bool, name string, versions map[string]int) []string {
+func computeMetadataPaths(consistentSnapshot bool, name string, versions map[string]int64) []string {
 	copyVersion := false
 
 	switch name {

--- a/repo.go
+++ b/repo.go
@@ -143,7 +143,7 @@ func (r *Repo) snapshot() (*data.Snapshot, error) {
 	return snapshot, nil
 }
 
-func (r *Repo) RootVersion() (int, error) {
+func (r *Repo) RootVersion() (int64, error) {
 	root, err := r.root()
 	if err != nil {
 		return -1, err
@@ -202,7 +202,7 @@ func (r *Repo) Targets() (data.TargetFiles, error) {
 	return targets.Targets, nil
 }
 
-func (r *Repo) SetTargetsVersion(v int) error {
+func (r *Repo) SetTargetsVersion(v int64) error {
 	t, err := r.topLevelTargets()
 	if err != nil {
 		return err
@@ -211,7 +211,7 @@ func (r *Repo) SetTargetsVersion(v int) error {
 	return r.setTopLevelMeta("targets.json", t)
 }
 
-func (r *Repo) TargetsVersion() (int, error) {
+func (r *Repo) TargetsVersion() (int64, error) {
 	t, err := r.topLevelTargets()
 	if err != nil {
 		return -1, err
@@ -219,7 +219,7 @@ func (r *Repo) TargetsVersion() (int, error) {
 	return t.Version, nil
 }
 
-func (r *Repo) SetTimestampVersion(v int) error {
+func (r *Repo) SetTimestampVersion(v int64) error {
 	ts, err := r.timestamp()
 	if err != nil {
 		return err
@@ -228,7 +228,7 @@ func (r *Repo) SetTimestampVersion(v int) error {
 	return r.setTopLevelMeta("timestamp.json", ts)
 }
 
-func (r *Repo) TimestampVersion() (int, error) {
+func (r *Repo) TimestampVersion() (int64, error) {
 	ts, err := r.timestamp()
 	if err != nil {
 		return -1, err
@@ -236,7 +236,7 @@ func (r *Repo) TimestampVersion() (int, error) {
 	return ts.Version, nil
 }
 
-func (r *Repo) SetSnapshotVersion(v int) error {
+func (r *Repo) SetSnapshotVersion(v int64) error {
 	s, err := r.snapshot()
 	if err != nil {
 		return err
@@ -246,7 +246,7 @@ func (r *Repo) SetSnapshotVersion(v int) error {
 	return r.setTopLevelMeta("snapshot.json", s)
 }
 
-func (r *Repo) SnapshotVersion() (int, error) {
+func (r *Repo) SnapshotVersion() (int64, error) {
 	s, err := r.snapshot()
 	if err != nil {
 		return -1, err
@@ -903,7 +903,7 @@ func (r *Repo) TimestampWithExpires(expires time.Time) error {
 	return err
 }
 
-func (r *Repo) fileVersions() (map[string]int, error) {
+func (r *Repo) fileVersions() (map[string]int64, error) {
 	root, err := r.root()
 	if err != nil {
 		return nil, err
@@ -916,7 +916,7 @@ func (r *Repo) fileVersions() (map[string]int, error) {
 	if err != nil {
 		return nil, err
 	}
-	versions := make(map[string]int)
+	versions := make(map[string]int64)
 	versions["root.json"] = root.Version
 	versions["targets.json"] = targets.Version
 	versions["snapshot.json"] = snapshot.Version

--- a/repo_test.go
+++ b/repo_test.go
@@ -123,28 +123,28 @@ func testNewRepo(c *C, newRepo func(local LocalStore, hashAlgorithms ...string) 
 	root, err := r.root()
 	c.Assert(err, IsNil)
 	c.Assert(root.Type, Equals, "root")
-	c.Assert(root.Version, Equals, 1)
+	c.Assert(root.Version, Equals, int64(1))
 	c.Assert(root.Keys, NotNil)
 	c.Assert(root.Keys, HasLen, 0)
 
 	targets, err := r.topLevelTargets()
 	c.Assert(err, IsNil)
 	c.Assert(targets.Type, Equals, "targets")
-	c.Assert(targets.Version, Equals, 1)
+	c.Assert(targets.Version, Equals, int64(1))
 	c.Assert(targets.Targets, NotNil)
 	c.Assert(targets.Targets, HasLen, 0)
 
 	snapshot, err := r.snapshot()
 	c.Assert(err, IsNil)
 	c.Assert(snapshot.Type, Equals, "snapshot")
-	c.Assert(snapshot.Version, Equals, 1)
+	c.Assert(snapshot.Version, Equals, int64(1))
 	c.Assert(snapshot.Meta, NotNil)
 	c.Assert(snapshot.Meta, HasLen, 0)
 
 	timestamp, err := r.timestamp()
 	c.Assert(err, IsNil)
 	c.Assert(timestamp.Type, Equals, "timestamp")
-	c.Assert(timestamp.Version, Equals, 1)
+	c.Assert(timestamp.Version, Equals, int64(1))
 	c.Assert(timestamp.Meta, NotNil)
 	c.Assert(timestamp.Meta, HasLen, 0)
 }
@@ -354,7 +354,7 @@ func (rs *RepoSuite) TestAddPrivateKey(c *C) {
 	// check root metadata is correct
 	root, err := r.root()
 	c.Assert(err, IsNil)
-	c.Assert(root.Version, Equals, 1)
+	c.Assert(root.Version, Equals, int64(1))
 	c.Assert(root.Roles, NotNil)
 	c.Assert(root.Roles, HasLen, 1)
 	rs.assertNumUniqueKeys(c, root, "root", 1)
@@ -768,19 +768,19 @@ func (rs *RepoSuite) TestCommitVersions(c *C) {
 	// on initial commit everything should be at version 1.
 	rootVersion, err := r.RootVersion()
 	c.Assert(err, IsNil)
-	c.Assert(rootVersion, Equals, 1)
+	c.Assert(rootVersion, Equals, int64(1))
 
 	targetsVersion, err := r.TargetsVersion()
 	c.Assert(err, IsNil)
-	c.Assert(targetsVersion, Equals, 1)
+	c.Assert(targetsVersion, Equals, int64(1))
 
 	snapshotVersion, err := r.SnapshotVersion()
 	c.Assert(err, IsNil)
-	c.Assert(snapshotVersion, Equals, 1)
+	c.Assert(snapshotVersion, Equals, int64(1))
 
 	timestampVersion, err := r.SnapshotVersion()
 	c.Assert(err, IsNil)
-	c.Assert(timestampVersion, Equals, 1)
+	c.Assert(timestampVersion, Equals, int64(1))
 
 	// taking a snapshot should only increment snapshot and timestamp.
 	c.Assert(r.Snapshot(), IsNil)
@@ -789,19 +789,19 @@ func (rs *RepoSuite) TestCommitVersions(c *C) {
 
 	rootVersion, err = r.RootVersion()
 	c.Assert(err, IsNil)
-	c.Assert(rootVersion, Equals, 1)
+	c.Assert(rootVersion, Equals, int64(1))
 
 	targetsVersion, err = r.TargetsVersion()
 	c.Assert(err, IsNil)
-	c.Assert(targetsVersion, Equals, 1)
+	c.Assert(targetsVersion, Equals, int64(1))
 
 	snapshotVersion, err = r.SnapshotVersion()
 	c.Assert(err, IsNil)
-	c.Assert(snapshotVersion, Equals, 2)
+	c.Assert(snapshotVersion, Equals, int64(2))
 
 	timestampVersion, err = r.SnapshotVersion()
 	c.Assert(err, IsNil)
-	c.Assert(timestampVersion, Equals, 2)
+	c.Assert(timestampVersion, Equals, int64(2))
 
 	// rotating multiple keys should increment the root once.
 	genKey(c, r, "targets")
@@ -813,19 +813,19 @@ func (rs *RepoSuite) TestCommitVersions(c *C) {
 
 	rootVersion, err = r.RootVersion()
 	c.Assert(err, IsNil)
-	c.Assert(rootVersion, Equals, 2)
+	c.Assert(rootVersion, Equals, int64(2))
 
 	targetsVersion, err = r.TargetsVersion()
 	c.Assert(err, IsNil)
-	c.Assert(targetsVersion, Equals, 1)
+	c.Assert(targetsVersion, Equals, int64(1))
 
 	snapshotVersion, err = r.SnapshotVersion()
 	c.Assert(err, IsNil)
-	c.Assert(snapshotVersion, Equals, 3)
+	c.Assert(snapshotVersion, Equals, int64(3))
 
 	timestampVersion, err = r.TimestampVersion()
 	c.Assert(err, IsNil)
-	c.Assert(timestampVersion, Equals, 3)
+	c.Assert(timestampVersion, Equals, int64(3))
 }
 
 type tmpDir struct {
@@ -862,11 +862,11 @@ func (t *tmpDir) assertHashedFilesNotExist(path string, hashes data.Hashes) {
 	}
 }
 
-func (t *tmpDir) assertVersionedFileExist(path string, version int) {
+func (t *tmpDir) assertVersionedFileExist(path string, version int64) {
 	t.assertExists(util.VersionedPath(path, version))
 }
 
-func (t *tmpDir) assertVersionedFileNotExist(path string, version int) {
+func (t *tmpDir) assertVersionedFileNotExist(path string, version int64) {
 	t.assertNotExist(util.VersionedPath(path, version))
 }
 
@@ -1034,9 +1034,9 @@ func (rs *RepoSuite) TestConsistentSnapshot(c *C) {
 
 	versions, err := r.fileVersions()
 	c.Assert(err, IsNil)
-	c.Assert(versions["root.json"], Equals, 1)
-	c.Assert(versions["targets.json"], Equals, 1)
-	c.Assert(versions["snapshot.json"], Equals, 1)
+	c.Assert(versions["root.json"], Equals, int64(1))
+	c.Assert(versions["targets.json"], Equals, int64(1))
+	c.Assert(versions["snapshot.json"], Equals, int64(1))
 
 	hashes, err := r.fileHashes()
 	c.Assert(err, IsNil)
@@ -1072,9 +1072,9 @@ func (rs *RepoSuite) TestConsistentSnapshot(c *C) {
 
 	versions, err = r.fileVersions()
 	c.Assert(err, IsNil)
-	c.Assert(versions["root.json"], Equals, 1)
-	c.Assert(versions["targets.json"], Equals, 2)
-	c.Assert(versions["snapshot.json"], Equals, 2)
+	c.Assert(versions["root.json"], Equals, int64(1))
+	c.Assert(versions["targets.json"], Equals, int64(2))
+	c.Assert(versions["snapshot.json"], Equals, int64(2))
 
 	// Save the old hashes for foo.txt to make sure we can assert it doesn't exist later.
 	fooHashes := hashes["targets/foo.txt"]
@@ -1136,7 +1136,7 @@ func (rs *RepoSuite) TestExpiresAndVersion(c *C) {
 
 	root, err := r.root()
 	c.Assert(err, IsNil)
-	c.Assert(root.Version, Equals, 1)
+	c.Assert(root.Version, Equals, int64(1))
 
 	expires := time.Now().Add(24 * time.Hour)
 	_, err = r.GenKeyWithExpires("root", expires)
@@ -1147,7 +1147,7 @@ func (rs *RepoSuite) TestExpiresAndVersion(c *C) {
 	root, err = r.root()
 	c.Assert(err, IsNil)
 	c.Assert(root.Expires.Unix(), DeepEquals, expires.Round(time.Second).Unix())
-	c.Assert(root.Version, Equals, 2)
+	c.Assert(root.Version, Equals, int64(2))
 
 	expires = time.Now().Add(12 * time.Hour)
 	role, ok := root.Roles["root"]
@@ -1162,7 +1162,7 @@ func (rs *RepoSuite) TestExpiresAndVersion(c *C) {
 	root, err = r.root()
 	c.Assert(err, IsNil)
 	c.Assert(root.Expires.Unix(), DeepEquals, expires.Round(time.Second).Unix())
-	c.Assert(root.Version, Equals, 3)
+	c.Assert(root.Version, Equals, int64(3))
 
 	expires = time.Now().Add(6 * time.Hour)
 	c.Assert(r.AddTargetWithExpires("foo.txt", nil, expires), IsNil)
@@ -1172,7 +1172,7 @@ func (rs *RepoSuite) TestExpiresAndVersion(c *C) {
 	targets, err := r.topLevelTargets()
 	c.Assert(err, IsNil)
 	c.Assert(targets.Expires.Unix(), Equals, expires.Round(time.Second).Unix())
-	c.Assert(targets.Version, Equals, 2)
+	c.Assert(targets.Version, Equals, int64(2))
 
 	expires = time.Now().Add(2 * time.Hour)
 	c.Assert(r.RemoveTargetWithExpires("foo.txt", expires), IsNil)
@@ -1182,7 +1182,7 @@ func (rs *RepoSuite) TestExpiresAndVersion(c *C) {
 	targets, err = r.topLevelTargets()
 	c.Assert(err, IsNil)
 	c.Assert(targets.Expires.Unix(), Equals, expires.Round(time.Second).Unix())
-	c.Assert(targets.Version, Equals, 3)
+	c.Assert(targets.Version, Equals, int64(3))
 
 	expires = time.Now().Add(time.Hour)
 	c.Assert(r.SnapshotWithExpires(expires), IsNil)
@@ -1191,7 +1191,7 @@ func (rs *RepoSuite) TestExpiresAndVersion(c *C) {
 	snapshot, err := r.snapshot()
 	c.Assert(err, IsNil)
 	c.Assert(snapshot.Expires.Unix(), Equals, expires.Round(time.Second).Unix())
-	c.Assert(snapshot.Version, Equals, 6)
+	c.Assert(snapshot.Version, Equals, int64(6))
 
 	_, snapshotHasRoot := snapshot.Meta["root.json"]
 	c.Assert(snapshotHasRoot, Equals, false)
@@ -1202,7 +1202,7 @@ func (rs *RepoSuite) TestExpiresAndVersion(c *C) {
 	c.Assert(r.Commit(), IsNil)
 	snapshot, err = r.snapshot()
 	c.Assert(err, IsNil)
-	c.Assert(snapshot.Version, Equals, 7)
+	c.Assert(snapshot.Version, Equals, int64(7))
 
 	expires = time.Now().Add(10 * time.Minute)
 	c.Assert(r.TimestampWithExpires(expires), IsNil)
@@ -1210,13 +1210,13 @@ func (rs *RepoSuite) TestExpiresAndVersion(c *C) {
 	timestamp, err := r.timestamp()
 	c.Assert(err, IsNil)
 	c.Assert(timestamp.Expires.Unix(), Equals, expires.Round(time.Second).Unix())
-	c.Assert(timestamp.Version, Equals, 8)
+	c.Assert(timestamp.Version, Equals, int64(8))
 
 	c.Assert(r.Timestamp(), IsNil)
 	c.Assert(r.Commit(), IsNil)
 	timestamp, err = r.timestamp()
 	c.Assert(err, IsNil)
-	c.Assert(timestamp.Version, Equals, 9)
+	c.Assert(timestamp.Version, Equals, int64(9))
 	c.Assert(timestamp.Meta["snapshot.json"].Version, Equals, snapshot.Version)
 }
 
@@ -1550,7 +1550,7 @@ func (rs *RepoSuite) TestUnknownKeyIDs(c *C) {
 
 	root, err := r.root()
 	c.Assert(err, IsNil)
-	c.Assert(root.Version, Equals, 1)
+	c.Assert(root.Version, Equals, int64(1))
 
 	root.Keys["unknown-key-id"] = signer.PublicData()
 	r.setTopLevelMeta("root.json", root)
@@ -1574,7 +1574,7 @@ func (rs *RepoSuite) TestUnknownKeyIDs(c *C) {
 		Signatures []data.Signature `json:"signatures"`
 	}
 	c.Assert(json.Unmarshal(rootJSON, &signedRoot), IsNil)
-	c.Assert(signedRoot.Signed.Version, Equals, 1)
+	c.Assert(signedRoot.Signed.Version, Equals, int64(1))
 
 	unknownKey, ok := signedRoot.Signed.Keys["unknown-key-id"]
 	c.Assert(ok, Equals, true)
@@ -1597,7 +1597,7 @@ func (rs *RepoSuite) TestUnknownKeyIDs(c *C) {
 	c.Assert(ok, Equals, true)
 
 	c.Assert(json.Unmarshal(rootJSON, &signedRoot), IsNil)
-	c.Assert(signedRoot.Signed.Version, Equals, 2)
+	c.Assert(signedRoot.Signed.Version, Equals, int64(2))
 
 	unknownKey, ok = signedRoot.Signed.Keys["unknown-key-id"]
 	c.Assert(ok, Equals, true)
@@ -1651,19 +1651,19 @@ func (rs *RepoSuite) TestThreshold(c *C) {
 	// Check versions updated
 	rootVersion, err := r.RootVersion()
 	c.Assert(err, IsNil)
-	c.Assert(rootVersion, Equals, 2)
+	c.Assert(rootVersion, Equals, int64(2))
 
 	targetsVersion, err := r.TargetsVersion()
 	c.Assert(err, IsNil)
-	c.Assert(targetsVersion, Equals, 1)
+	c.Assert(targetsVersion, Equals, int64(1))
 
 	snapshotVersion, err := r.SnapshotVersion()
 	c.Assert(err, IsNil)
-	c.Assert(snapshotVersion, Equals, 2)
+	c.Assert(snapshotVersion, Equals, int64(2))
 
 	timestampVersion, err := r.TimestampVersion()
 	c.Assert(err, IsNil)
-	c.Assert(timestampVersion, Equals, 2)
+	c.Assert(timestampVersion, Equals, int64(2))
 }
 
 func (rs *RepoSuite) TestAddOrUpdateSignatures(c *C) {

--- a/util/util.go
+++ b/util/util.go
@@ -30,8 +30,8 @@ func (e ErrWrongLength) Error() string {
 }
 
 type ErrWrongVersion struct {
-	Expected int
-	Actual   int
+	Expected int64
+	Actual   int64
 }
 
 func (e ErrWrongVersion) Error() string {
@@ -102,7 +102,7 @@ func hashEqual(actual data.Hashes, expected data.Hashes) error {
 	return nil
 }
 
-func versionEqual(actual int, expected int) error {
+func versionEqual(actual int64, expected int64) error {
 	if actual != expected {
 		return ErrWrongVersion{expected, actual}
 	}
@@ -183,10 +183,10 @@ func GenerateFileMeta(r io.Reader, hashAlgorithms ...string) (data.FileMeta, err
 }
 
 type versionedMeta struct {
-	Version int `json:"version"`
+	Version int64 `json:"version"`
 }
 
-func generateVersionedFileMeta(r io.Reader, hashAlgorithms ...string) (data.FileMeta, int, error) {
+func generateVersionedFileMeta(r io.Reader, hashAlgorithms ...string) (data.FileMeta, int64, error) {
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
 		return data.FileMeta{}, 0, err
@@ -253,8 +253,8 @@ func NormalizeTarget(p string) string {
 	return strings.TrimPrefix(path.Join("/", p), "/")
 }
 
-func VersionedPath(p string, version int) string {
-	return path.Join(path.Dir(p), strconv.Itoa(version)+"."+path.Base(p))
+func VersionedPath(p string, version int64) string {
+	return path.Join(path.Dir(p), strconv.FormatInt(version, 10)+"."+path.Base(p))
 }
 
 func HashedPaths(p string, hashes data.Hashes) []string {

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -113,7 +113,7 @@ func (UtilSuite) TestSnapshotFileMetaEqual(c *C) {
 		err      func(test) error
 	}
 
-	fileMeta := func(version int, length int64, hashes map[string]string) data.SnapshotFileMeta {
+	fileMeta := func(version int64, length int64, hashes map[string]string) data.SnapshotFileMeta {
 		return data.SnapshotFileMeta{
 			FileMeta: data.FileMeta{
 				Length: length,

--- a/verify/errors.go
+++ b/verify/errors.go
@@ -43,8 +43,8 @@ func (e ErrExpired) Error() string {
 }
 
 type ErrLowVersion struct {
-	Actual  int
-	Current int
+	Actual  int64
+	Current int64
 }
 
 func (e ErrLowVersion) Error() string {
@@ -52,8 +52,8 @@ func (e ErrLowVersion) Error() string {
 }
 
 type ErrWrongVersion struct {
-	Given    int
-	Expected int
+	Given    int64
+	Expected int64
 }
 
 func (e ErrWrongVersion) Error() string {

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -13,10 +13,10 @@ import (
 type signedMeta struct {
 	Type    string    `json:"_type"`
 	Expires time.Time `json:"expires"`
-	Version int       `json:"version"`
+	Version int64     `json:"version"`
 }
 
-func (db *DB) VerifyIgnoreExpiredCheck(s *data.Signed, role string, minVersion int) error {
+func (db *DB) VerifyIgnoreExpiredCheck(s *data.Signed, role string, minVersion int64) error {
 	if err := db.VerifySignatures(s, role); err != nil {
 		return err
 	}
@@ -46,7 +46,7 @@ func (db *DB) VerifyIgnoreExpiredCheck(s *data.Signed, role string, minVersion i
 	return nil
 }
 
-func (db *DB) Verify(s *data.Signed, role string, minVersion int) error {
+func (db *DB) Verify(s *data.Signed, role string, minVersion int64) error {
 
 	err := db.VerifyIgnoreExpiredCheck(s, role, minVersion)
 
@@ -124,7 +124,7 @@ func (db *DB) VerifySignatures(s *data.Signed, role string) error {
 	return nil
 }
 
-func (db *DB) Unmarshal(b []byte, v interface{}, role string, minVersion int) error {
+func (db *DB) Unmarshal(b []byte, v interface{}, role string, minVersion int64) error {
 	s := &data.Signed{}
 	if err := json.Unmarshal(b, s); err != nil {
 		return err
@@ -136,7 +136,7 @@ func (db *DB) Unmarshal(b []byte, v interface{}, role string, minVersion int) er
 }
 
 // UnmarshalExpired is exactly like Unmarshal except ignores expired timestamp error.
-func (db *DB) UnmarshalIgnoreExpired(b []byte, v interface{}, role string, minVersion int) error {
+func (db *DB) UnmarshalIgnoreExpired(b []byte, v interface{}, role string, minVersion int64) error {
 	s := &data.Signed{}
 	if err := json.Unmarshal(b, s); err != nil {
 		return err

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -68,7 +68,7 @@ func (VerifySuite) Test(c *C) {
 		keys  []*data.PublicKey
 		roles map[string]*data.Role
 		s     *data.Signed
-		ver   int
+		ver   int64
 		exp   *time.Time
 		typ   string
 		role  string
@@ -77,7 +77,7 @@ func (VerifySuite) Test(c *C) {
 	}
 
 	expiredTime := time.Now().Add(-time.Hour)
-	minVer := 10
+	minVer := int64(10)
 	tests := []test{
 		{
 			name: "no signatures",
@@ -255,7 +255,7 @@ func (VerifySuite) Test(c *C) {
 }
 
 func (VerifySuite) TestVerifyIgnoreExpired(c *C) {
-	minVer := 10
+	minVer := int64(10)
 	role := "root"
 	k, _ := keys.GenerateEd25519Key()
 	s, _ := sign.Marshal(&signedMeta{Type: role, Version: minVer, Expires: time.Now().Add(-time.Hour)}, k)


### PR DESCRIPTION
Release Notes: Metadata version now uses int64

**Types of changes**:
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Description of the changes being introduced by the pull request**:

We have a high write throughput on our TUF repositories and there's a good chance we'll reach 2B+ snapshots versions in the future which would break our clients on 32bit archs. Let's standardize to `int64` to avoid any surprises.