### PR TITLE
fix: Fix JSON canonicalisation

### DIFF
--- a/client/testdata/go-tuf/consistent-snapshot-false/0/repository/1.root.json
+++ b/client/testdata/go-tuf/consistent-snapshot-false/0/repository/1.root.json
@@ -1,58 +1,53 @@
 {
-	"signatures": [
-		{
-			"keyid": "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add",
-			"sig": "afab8b34f93c99e200505cc6f0d6a9c4e757a7229f96bd31ab618f8bc4c3abe491b372bfec9d231136de46c1e183df194d372360ee9d32652f8c04d7574e2608"
-		}
-	],
 	"signed": {
 		"_type": "root",
-		"consistent_snapshot": false,
+		"spec_version": "1.0",
+		"version": 1,
 		"expires": "2100-01-01T00:00:00Z",
 		"keys": {
 			"289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "d482fa4805a50870aa1356ace6b764f7ab47ed4dc38f49b1a189afa25f179e94"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "62f71f99c788f16bcdc8bb252455e3a690350e4ddea5a6aab1f9a3aaabcf369a"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "bca152214dbfd3e7a1b7a7b3e2cc179fb00520fd7212c8a60ba99f14dfc0e1ca"
-				},
-				"scheme": "ed25519"
+				}
 			}
 		},
 		"roles": {
@@ -81,7 +76,12 @@
 				"threshold": 1
 			}
 		},
-		"spec_version": "1.0",
-		"version": 1
-	}
+		"consistent_snapshot": false
+	},
+	"signatures": [
+		{
+			"keyid": "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add",
+			"sig": "afab8b34f93c99e200505cc6f0d6a9c4e757a7229f96bd31ab618f8bc4c3abe491b372bfec9d231136de46c1e183df194d372360ee9d32652f8c04d7574e2608"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-false/0/repository/root.json
+++ b/client/testdata/go-tuf/consistent-snapshot-false/0/repository/root.json
@@ -1,58 +1,53 @@
 {
-	"signatures": [
-		{
-			"keyid": "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add",
-			"sig": "afab8b34f93c99e200505cc6f0d6a9c4e757a7229f96bd31ab618f8bc4c3abe491b372bfec9d231136de46c1e183df194d372360ee9d32652f8c04d7574e2608"
-		}
-	],
 	"signed": {
 		"_type": "root",
-		"consistent_snapshot": false,
+		"spec_version": "1.0",
+		"version": 1,
 		"expires": "2100-01-01T00:00:00Z",
 		"keys": {
 			"289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "d482fa4805a50870aa1356ace6b764f7ab47ed4dc38f49b1a189afa25f179e94"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "62f71f99c788f16bcdc8bb252455e3a690350e4ddea5a6aab1f9a3aaabcf369a"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "bca152214dbfd3e7a1b7a7b3e2cc179fb00520fd7212c8a60ba99f14dfc0e1ca"
-				},
-				"scheme": "ed25519"
+				}
 			}
 		},
 		"roles": {
@@ -81,7 +76,12 @@
 				"threshold": 1
 			}
 		},
-		"spec_version": "1.0",
-		"version": 1
-	}
+		"consistent_snapshot": false
+	},
+	"signatures": [
+		{
+			"keyid": "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add",
+			"sig": "afab8b34f93c99e200505cc6f0d6a9c4e757a7229f96bd31ab618f8bc4c3abe491b372bfec9d231136de46c1e183df194d372360ee9d32652f8c04d7574e2608"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-false/0/repository/snapshot.json
+++ b/client/testdata/go-tuf/consistent-snapshot-false/0/repository/snapshot.json
@@ -1,23 +1,23 @@
 {
-	"signatures": [
-		{
-			"keyid": "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45",
-			"sig": "3f24a81d61a8f1fbe2bf310a9d8263c7b3a5fc87524b92e00a100ce6d8e0f742c0ef05b017234b0d08c9cf4da4591deb65e6f76340afad722b3db1b25d2e0203"
-		}
-	],
 	"signed": {
 		"_type": "snapshot",
+		"spec_version": "1.0",
+		"version": 1,
 		"expires": "2100-01-01T00:00:00Z",
 		"meta": {
 			"targets.json": {
-				"hashes": {
-					"sha512": "e0dd9a3833d117cd7bb6fdaae8923d5bda0661cb242be067813bfec3114d83943230b8bb7fcbf093a15d5840f1ecd969f44d3df13e2045d3fb7d22903fbc1bf5"
-				},
 				"length": 588,
+				"hashes": {
+					"sha512": "2532c645262d3a15db2afc561d9ae75db96c3b42abe8bd994c173e45ea70177bc1b080e211d92b6f244d267dcb0a0bc2fbcd1c2b008881c19f950c5e8c0035ec"
+				},
 				"version": 1
 			}
-		},
-		"spec_version": "1.0",
-		"version": 1
-	}
+		}
+	},
+	"signatures": [
+		{
+			"keyid": "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45",
+			"sig": "6efc0efbc7a3b849a58e9cb394af10fe6d199d2ead18e6931932c85f44269d5d73e8f18808d0d9b66fbfd9926b0bda9d2d26a7508a960758c0b84eb8aa31ac0b"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-false/0/repository/targets.json
+++ b/client/testdata/go-tuf/consistent-snapshot-false/0/repository/targets.json
@@ -1,22 +1,22 @@
 {
+	"signed": {
+		"_type": "targets",
+		"spec_version": "1.0",
+		"version": 1,
+		"expires": "2100-01-01T00:00:00Z",
+		"targets": {
+			"0": {
+				"length": 1,
+				"hashes": {
+					"sha512": "31bca02094eb78126a517b206a88c73cfa9ec6f704c7030d18212cace820f025f00bf0ea68dbf3f3a5436ca63b53bf7bf80ad8d5de7d8359d0b7fed9dbc3ab99"
+				}
+			}
+		}
+	},
 	"signatures": [
 		{
 			"keyid": "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937",
 			"sig": "4d5c3a5da43f3792d077c1128fa28585982ff2957fae59be02a831fc920d0b91cbeaa99fd6c15066ec4da8bf12f993440a90d1624fd7b0a68070e5d60ed2500f"
 		}
-	],
-	"signed": {
-		"_type": "targets",
-		"expires": "2100-01-01T00:00:00Z",
-		"spec_version": "1.0",
-		"targets": {
-			"0": {
-				"hashes": {
-					"sha512": "31bca02094eb78126a517b206a88c73cfa9ec6f704c7030d18212cace820f025f00bf0ea68dbf3f3a5436ca63b53bf7bf80ad8d5de7d8359d0b7fed9dbc3ab99"
-				},
-				"length": 1
-			}
-		},
-		"version": 1
-	}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-false/0/repository/timestamp.json
+++ b/client/testdata/go-tuf/consistent-snapshot-false/0/repository/timestamp.json
@@ -1,23 +1,23 @@
 {
-	"signatures": [
-		{
-			"keyid": "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8",
-			"sig": "cc163b290f68c6d41fbc7ca01a30416a43a5ee7652d2f99aff3c6ef01e5c2fa9d5f2caf0e745abeee3baa277ddfe43ac636149963cf085686345addc9e000301"
-		}
-	],
 	"signed": {
 		"_type": "timestamp",
+		"spec_version": "1.0",
+		"version": 1,
 		"expires": "2100-01-01T00:00:00Z",
 		"meta": {
 			"snapshot.json": {
-				"hashes": {
-					"sha512": "973d23a7e47e1003cd4f8c0e431b080171408e488084fe736b664433d9be76e1f1048ea76607c1f485f1dcb23ce2b4980257431c39cee0fddcc53559997cd565"
-				},
 				"length": 617,
+				"hashes": {
+					"sha512": "6fd318e2cc3bca35d2f597e504c095137263ffe3e72f5e5c64e6c7860bea1207448c8994066ffc1cf20898a9d1586cdf09be4e3ea06f69593ed5c7d772f8dfd1"
+				},
 				"version": 1
 			}
-		},
-		"spec_version": "1.0",
-		"version": 1
-	}
+		}
+	},
+	"signatures": [
+		{
+			"keyid": "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8",
+			"sig": "943b219ab6c651793da08d8cf38c7d25fb959c75161b5b86562983841433f9f38c237bb87cf6ecfbb3cb7c78113a3ed2651ee57d3515e7edfc3bebbf349f2809"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-false/1/repository/2.root.json
+++ b/client/testdata/go-tuf/consistent-snapshot-false/1/repository/2.root.json
@@ -1,62 +1,53 @@
 {
-	"signatures": [
-		{
-			"keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
-			"sig": "20e91b55c995989b270091b714347b15169285cb636ef05d68d49ed7b7a96ebfda13898e0d9ef928c382873b9dba90dca492dbf705d56a4b293adaaed574340f"
-		},
-		{
-			"keyid": "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add",
-			"sig": "65f63745aa8bd39132f827c427ea6d87f620ec805d9f376b6a8400dc3db7eb964e5423d31ed08867916d039661a70d6bf255bca552248021a4e78b5d357c2b0f"
-		}
-	],
 	"signed": {
 		"_type": "root",
-		"consistent_snapshot": false,
+		"spec_version": "1.0",
+		"version": 2,
 		"expires": "2100-01-01T00:00:00Z",
 		"keys": {
 			"289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "d482fa4805a50870aa1356ace6b764f7ab47ed4dc38f49b1a189afa25f179e94"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "62f71f99c788f16bcdc8bb252455e3a690350e4ddea5a6aab1f9a3aaabcf369a"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "153986a7370e002f377dd68797e7466c421180c1571e233de2f8ab41c8af4f54"
-				},
-				"scheme": "ed25519"
+				}
 			}
 		},
 		"roles": {
@@ -85,7 +76,16 @@
 				"threshold": 1
 			}
 		},
-		"spec_version": "1.0",
-		"version": 2
-	}
+		"consistent_snapshot": false
+	},
+	"signatures": [
+		{
+			"keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
+			"sig": "20e91b55c995989b270091b714347b15169285cb636ef05d68d49ed7b7a96ebfda13898e0d9ef928c382873b9dba90dca492dbf705d56a4b293adaaed574340f"
+		},
+		{
+			"keyid": "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add",
+			"sig": "65f63745aa8bd39132f827c427ea6d87f620ec805d9f376b6a8400dc3db7eb964e5423d31ed08867916d039661a70d6bf255bca552248021a4e78b5d357c2b0f"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-false/1/repository/root.json
+++ b/client/testdata/go-tuf/consistent-snapshot-false/1/repository/root.json
@@ -1,62 +1,53 @@
 {
-	"signatures": [
-		{
-			"keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
-			"sig": "20e91b55c995989b270091b714347b15169285cb636ef05d68d49ed7b7a96ebfda13898e0d9ef928c382873b9dba90dca492dbf705d56a4b293adaaed574340f"
-		},
-		{
-			"keyid": "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add",
-			"sig": "65f63745aa8bd39132f827c427ea6d87f620ec805d9f376b6a8400dc3db7eb964e5423d31ed08867916d039661a70d6bf255bca552248021a4e78b5d357c2b0f"
-		}
-	],
 	"signed": {
 		"_type": "root",
-		"consistent_snapshot": false,
+		"spec_version": "1.0",
+		"version": 2,
 		"expires": "2100-01-01T00:00:00Z",
 		"keys": {
 			"289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "d482fa4805a50870aa1356ace6b764f7ab47ed4dc38f49b1a189afa25f179e94"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "62f71f99c788f16bcdc8bb252455e3a690350e4ddea5a6aab1f9a3aaabcf369a"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "153986a7370e002f377dd68797e7466c421180c1571e233de2f8ab41c8af4f54"
-				},
-				"scheme": "ed25519"
+				}
 			}
 		},
 		"roles": {
@@ -85,7 +76,16 @@
 				"threshold": 1
 			}
 		},
-		"spec_version": "1.0",
-		"version": 2
-	}
+		"consistent_snapshot": false
+	},
+	"signatures": [
+		{
+			"keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
+			"sig": "20e91b55c995989b270091b714347b15169285cb636ef05d68d49ed7b7a96ebfda13898e0d9ef928c382873b9dba90dca492dbf705d56a4b293adaaed574340f"
+		},
+		{
+			"keyid": "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add",
+			"sig": "65f63745aa8bd39132f827c427ea6d87f620ec805d9f376b6a8400dc3db7eb964e5423d31ed08867916d039661a70d6bf255bca552248021a4e78b5d357c2b0f"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-false/1/repository/snapshot.json
+++ b/client/testdata/go-tuf/consistent-snapshot-false/1/repository/snapshot.json
@@ -1,23 +1,23 @@
 {
-	"signatures": [
-		{
-			"keyid": "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45",
-			"sig": "bded36f9992b8eb9444a276b397db2ce5f06a8be1273d7f84391b2a098778522a1c49185b2fc858aa99bc69fe820f2444bc8e5077f447ddcf42515c3a7026e0a"
-		}
-	],
 	"signed": {
 		"_type": "snapshot",
+		"spec_version": "1.0",
+		"version": 2,
 		"expires": "2100-01-01T00:00:00Z",
 		"meta": {
 			"targets.json": {
-				"hashes": {
-					"sha512": "8672c435a53519972738fada6ed3b7fa37b3ea42b4fa1e436b774e697a8d696d9efbeb6c590a6e16dec0a5e7f789da82ea59a68fae63f343340d1549a075ab1b"
-				},
 				"length": 789,
+				"hashes": {
+					"sha512": "7a919ed2a5fb7cf80252c9307ac4d27bc2ab54f9bb803389977dcc3d09ae7dff533639c1b19a810d2b212a5c5e904e0f73ab01324ba79dffbb9f7488204caf2a"
+				},
 				"version": 2
 			}
-		},
-		"spec_version": "1.0",
-		"version": 2
-	}
+		}
+	},
+	"signatures": [
+		{
+			"keyid": "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45",
+			"sig": "9a3734441c38daa3275ba60a2178b8dfe5f98296f408bf434144b4bd4f68af73b7f6860e6f2e638b93144ac5bebe361642bbff66a1195596bb8c841429b34508"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-false/1/repository/targets.json
+++ b/client/testdata/go-tuf/consistent-snapshot-false/1/repository/targets.json
@@ -1,28 +1,28 @@
 {
+	"signed": {
+		"_type": "targets",
+		"spec_version": "1.0",
+		"version": 2,
+		"expires": "2100-01-01T00:00:00Z",
+		"targets": {
+			"0": {
+				"length": 1,
+				"hashes": {
+					"sha512": "31bca02094eb78126a517b206a88c73cfa9ec6f704c7030d18212cace820f025f00bf0ea68dbf3f3a5436ca63b53bf7bf80ad8d5de7d8359d0b7fed9dbc3ab99"
+				}
+			},
+			"1": {
+				"length": 1,
+				"hashes": {
+					"sha512": "4dff4ea340f0a823f15d3f4f01ab62eae0e5da579ccb851f8db9dfe84c58b2b37b89903a740e1ee172da793a6e79d560e5f7f9bd058a12a280433ed6fa46510a"
+				}
+			}
+		}
+	},
 	"signatures": [
 		{
 			"keyid": "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937",
 			"sig": "81bcf5921834a20b8b0946815ad4316f43ffce20b3793e6653dc5fd4b98f1c6318ce2243948574e82414a102717a6f2d731250b3191c54abc8391fd867503e0b"
 		}
-	],
-	"signed": {
-		"_type": "targets",
-		"expires": "2100-01-01T00:00:00Z",
-		"spec_version": "1.0",
-		"targets": {
-			"0": {
-				"hashes": {
-					"sha512": "31bca02094eb78126a517b206a88c73cfa9ec6f704c7030d18212cace820f025f00bf0ea68dbf3f3a5436ca63b53bf7bf80ad8d5de7d8359d0b7fed9dbc3ab99"
-				},
-				"length": 1
-			},
-			"1": {
-				"hashes": {
-					"sha512": "4dff4ea340f0a823f15d3f4f01ab62eae0e5da579ccb851f8db9dfe84c58b2b37b89903a740e1ee172da793a6e79d560e5f7f9bd058a12a280433ed6fa46510a"
-				},
-				"length": 1
-			}
-		},
-		"version": 2
-	}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-false/1/repository/timestamp.json
+++ b/client/testdata/go-tuf/consistent-snapshot-false/1/repository/timestamp.json
@@ -1,23 +1,23 @@
 {
-	"signatures": [
-		{
-			"keyid": "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8",
-			"sig": "8ab93c7453677374d1483c495b49d80128b589ca80c1f3e7806bb3c40bd8be793c6df492ce68b2bcf5d50af73fdf7694b0484093b31577720898d6882ae97d0f"
-		}
-	],
 	"signed": {
 		"_type": "timestamp",
+		"spec_version": "1.0",
+		"version": 2,
 		"expires": "2100-01-01T00:00:00Z",
 		"meta": {
 			"snapshot.json": {
-				"hashes": {
-					"sha512": "957e34523e34c2316a9fd02744162834382101796efca153e35028eb1e3fe970427d4e60e375300d1ac92e1c0a8ec74a1b5575a29d337b3454083a76cb922959"
-				},
 				"length": 617,
+				"hashes": {
+					"sha512": "d7204efe9ded4f18d679d75054f43b02b20d74189ea81ad90a67399a8884a810e380a4d343e284c4b6fde506e22a464038871d06950166548a84a76344e2bf3a"
+				},
 				"version": 2
 			}
-		},
-		"spec_version": "1.0",
-		"version": 2
-	}
+		}
+	},
+	"signatures": [
+		{
+			"keyid": "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8",
+			"sig": "85c5afdd9dd3777d2cb31721519ab2942edffc9e1282b65b2cede505a469051ac5e86388461db49f948a5998b132dddb5ce0156d21622a6d2201fb93322de20f"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-false/2/repository/3.root.json
+++ b/client/testdata/go-tuf/consistent-snapshot-false/2/repository/3.root.json
@@ -1,58 +1,53 @@
 {
-	"signatures": [
-		{
-			"keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
-			"sig": "cfe8b0919d1707ca6c23501909b77c8b94d1ede2b85a3081ab7146244cc6fe436b06ad58163919276f2e37ddbcc13a0dde4851301053dcea2a9bcabc5e1cd004"
-		}
-	],
 	"signed": {
 		"_type": "root",
-		"consistent_snapshot": false,
+		"spec_version": "1.0",
+		"version": 3,
 		"expires": "2100-01-01T00:00:00Z",
 		"keys": {
 			"289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "d482fa4805a50870aa1356ace6b764f7ab47ed4dc38f49b1a189afa25f179e94"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "153986a7370e002f377dd68797e7466c421180c1571e233de2f8ab41c8af4f54"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "aee574e56780ea1709a8b56e02d4ffdd9a3a1deaed61e2eb0701f376a4422e42"
-				},
-				"scheme": "ed25519"
+				}
 			}
 		},
 		"roles": {
@@ -81,7 +76,12 @@
 				"threshold": 1
 			}
 		},
-		"spec_version": "1.0",
-		"version": 3
-	}
+		"consistent_snapshot": false
+	},
+	"signatures": [
+		{
+			"keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
+			"sig": "cfe8b0919d1707ca6c23501909b77c8b94d1ede2b85a3081ab7146244cc6fe436b06ad58163919276f2e37ddbcc13a0dde4851301053dcea2a9bcabc5e1cd004"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-false/2/repository/root.json
+++ b/client/testdata/go-tuf/consistent-snapshot-false/2/repository/root.json
@@ -1,58 +1,53 @@
 {
-	"signatures": [
-		{
-			"keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
-			"sig": "cfe8b0919d1707ca6c23501909b77c8b94d1ede2b85a3081ab7146244cc6fe436b06ad58163919276f2e37ddbcc13a0dde4851301053dcea2a9bcabc5e1cd004"
-		}
-	],
 	"signed": {
 		"_type": "root",
-		"consistent_snapshot": false,
+		"spec_version": "1.0",
+		"version": 3,
 		"expires": "2100-01-01T00:00:00Z",
 		"keys": {
 			"289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "d482fa4805a50870aa1356ace6b764f7ab47ed4dc38f49b1a189afa25f179e94"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "153986a7370e002f377dd68797e7466c421180c1571e233de2f8ab41c8af4f54"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "aee574e56780ea1709a8b56e02d4ffdd9a3a1deaed61e2eb0701f376a4422e42"
-				},
-				"scheme": "ed25519"
+				}
 			}
 		},
 		"roles": {
@@ -81,7 +76,12 @@
 				"threshold": 1
 			}
 		},
-		"spec_version": "1.0",
-		"version": 3
-	}
+		"consistent_snapshot": false
+	},
+	"signatures": [
+		{
+			"keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
+			"sig": "cfe8b0919d1707ca6c23501909b77c8b94d1ede2b85a3081ab7146244cc6fe436b06ad58163919276f2e37ddbcc13a0dde4851301053dcea2a9bcabc5e1cd004"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-false/2/repository/snapshot.json
+++ b/client/testdata/go-tuf/consistent-snapshot-false/2/repository/snapshot.json
@@ -1,23 +1,23 @@
 {
-	"signatures": [
-		{
-			"keyid": "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45",
-			"sig": "94a60aaddf390953b997b783bab689a2cbaf66610b4dee5645ef858480f709b61afefc5eb21c6131aa5d3e2248eccebe77a7b4a8462f6f8f7964680085053903"
-		}
-	],
 	"signed": {
 		"_type": "snapshot",
+		"spec_version": "1.0",
+		"version": 3,
 		"expires": "2100-01-01T00:00:00Z",
 		"meta": {
 			"targets.json": {
-				"hashes": {
-					"sha512": "b103f5cd1d68e0b5f7b96af03a27cf971460977976cff0b1d1371dcce6d45ef78e183fa26bf886f3864e84b8ddbbfc1bab7bd0e2be180ad82ed26f22a8e9b68b"
-				},
 				"length": 990,
+				"hashes": {
+					"sha512": "987022c23793b3d234d422c3ed4525f8c3771887db610fb2e7d6b455d27ad8b1b4a957a699d519c03754fe4feeb387ec84c95e1edac1d4e9b186bfbdff76ad10"
+				},
 				"version": 3
 			}
-		},
-		"spec_version": "1.0",
-		"version": 3
-	}
+		}
+	},
+	"signatures": [
+		{
+			"keyid": "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45",
+			"sig": "31896c9165a37aa54cf1c4d5f936035e092b1cf4c233ef35cd12c987aaa02de7ec99f26c198984fe0dcc21765d096b25cd67e7ca058613b2b2abef3193dd880d"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-false/2/repository/targets.json
+++ b/client/testdata/go-tuf/consistent-snapshot-false/2/repository/targets.json
@@ -1,34 +1,34 @@
 {
+	"signed": {
+		"_type": "targets",
+		"spec_version": "1.0",
+		"version": 3,
+		"expires": "2100-01-01T00:00:00Z",
+		"targets": {
+			"0": {
+				"length": 1,
+				"hashes": {
+					"sha512": "31bca02094eb78126a517b206a88c73cfa9ec6f704c7030d18212cace820f025f00bf0ea68dbf3f3a5436ca63b53bf7bf80ad8d5de7d8359d0b7fed9dbc3ab99"
+				}
+			},
+			"1": {
+				"length": 1,
+				"hashes": {
+					"sha512": "4dff4ea340f0a823f15d3f4f01ab62eae0e5da579ccb851f8db9dfe84c58b2b37b89903a740e1ee172da793a6e79d560e5f7f9bd058a12a280433ed6fa46510a"
+				}
+			},
+			"2": {
+				"length": 1,
+				"hashes": {
+					"sha512": "40b244112641dd78dd4f93b6c9190dd46e0099194d5a44257b7efad6ef9ff4683da1eda0244448cb343aa688f5d3efd7314dafe580ac0bcbf115aeca9e8dc114"
+				}
+			}
+		}
+	},
 	"signatures": [
 		{
 			"keyid": "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1",
 			"sig": "09593c7b47f4dbf1e8ac949fa010279ffbbd36070a54a89b689378441e8111602d4236fa2962063778c82027d4746a8973ba8fea86e9c105190da9fa362d8b0c"
 		}
-	],
-	"signed": {
-		"_type": "targets",
-		"expires": "2100-01-01T00:00:00Z",
-		"spec_version": "1.0",
-		"targets": {
-			"0": {
-				"hashes": {
-					"sha512": "31bca02094eb78126a517b206a88c73cfa9ec6f704c7030d18212cace820f025f00bf0ea68dbf3f3a5436ca63b53bf7bf80ad8d5de7d8359d0b7fed9dbc3ab99"
-				},
-				"length": 1
-			},
-			"1": {
-				"hashes": {
-					"sha512": "4dff4ea340f0a823f15d3f4f01ab62eae0e5da579ccb851f8db9dfe84c58b2b37b89903a740e1ee172da793a6e79d560e5f7f9bd058a12a280433ed6fa46510a"
-				},
-				"length": 1
-			},
-			"2": {
-				"hashes": {
-					"sha512": "40b244112641dd78dd4f93b6c9190dd46e0099194d5a44257b7efad6ef9ff4683da1eda0244448cb343aa688f5d3efd7314dafe580ac0bcbf115aeca9e8dc114"
-				},
-				"length": 1
-			}
-		},
-		"version": 3
-	}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-false/2/repository/timestamp.json
+++ b/client/testdata/go-tuf/consistent-snapshot-false/2/repository/timestamp.json
@@ -1,23 +1,23 @@
 {
-	"signatures": [
-		{
-			"keyid": "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8",
-			"sig": "e431037f03bb3e323aa6d9f97533883a0d111698a17cd7eb7843961fa4b15a12a98a8a6cac377df934a9303d3765cc5314f59a160ffe11a32e76c18c27b0180f"
-		}
-	],
 	"signed": {
 		"_type": "timestamp",
+		"spec_version": "1.0",
+		"version": 3,
 		"expires": "2100-01-01T00:00:00Z",
 		"meta": {
 			"snapshot.json": {
-				"hashes": {
-					"sha512": "49d07f15210a34a0b2bf51e2d349b243bba68800796a6f7031adaa14a86da0f3aa96098c46c6f55330fb71a424a6658cdf09683287f72f9082302e9be3aec1ef"
-				},
 				"length": 617,
+				"hashes": {
+					"sha512": "70d2f64bc810a0ae1c827c28eed47304c3a9c57402447d129aa3ac851d809a48bd0421aaa99e9e49055984e77f221510415cf27aca8f30f4db1767d6b7bd6024"
+				},
 				"version": 3
 			}
-		},
-		"spec_version": "1.0",
-		"version": 3
-	}
+		}
+	},
+	"signatures": [
+		{
+			"keyid": "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8",
+			"sig": "22367ebcf7c5265260b288e9fec6110257b8c8745af25f2b14c5d347ddab94f46893926bdd37c58d142089419708e446c5e3c1af5c47c51187fe69ca95038605"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-false/3/repository/4.root.json
+++ b/client/testdata/go-tuf/consistent-snapshot-false/3/repository/4.root.json
@@ -1,58 +1,53 @@
 {
-	"signatures": [
-		{
-			"keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
-			"sig": "3004c4b60645c6cca18e33835837a1639eead05355aa549f1d1304a22304e7058a50fb6188fc3617a47248eb7481de7a625f036cc69b53daf04a103b12768401"
-		}
-	],
 	"signed": {
 		"_type": "root",
-		"consistent_snapshot": false,
+		"spec_version": "1.0",
+		"version": 4,
 		"expires": "2100-01-01T00:00:00Z",
 		"keys": {
 			"aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "722dbc861813bb5b568524d62083e875c08e66fed1694d9161d253fa163dd86f"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "153986a7370e002f377dd68797e7466c421180c1571e233de2f8ab41c8af4f54"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "aee574e56780ea1709a8b56e02d4ffdd9a3a1deaed61e2eb0701f376a4422e42"
-				},
-				"scheme": "ed25519"
+				}
 			}
 		},
 		"roles": {
@@ -81,7 +76,12 @@
 				"threshold": 1
 			}
 		},
-		"spec_version": "1.0",
-		"version": 4
-	}
+		"consistent_snapshot": false
+	},
+	"signatures": [
+		{
+			"keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
+			"sig": "3004c4b60645c6cca18e33835837a1639eead05355aa549f1d1304a22304e7058a50fb6188fc3617a47248eb7481de7a625f036cc69b53daf04a103b12768401"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-false/3/repository/root.json
+++ b/client/testdata/go-tuf/consistent-snapshot-false/3/repository/root.json
@@ -1,58 +1,53 @@
 {
-	"signatures": [
-		{
-			"keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
-			"sig": "3004c4b60645c6cca18e33835837a1639eead05355aa549f1d1304a22304e7058a50fb6188fc3617a47248eb7481de7a625f036cc69b53daf04a103b12768401"
-		}
-	],
 	"signed": {
 		"_type": "root",
-		"consistent_snapshot": false,
+		"spec_version": "1.0",
+		"version": 4,
 		"expires": "2100-01-01T00:00:00Z",
 		"keys": {
 			"aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "722dbc861813bb5b568524d62083e875c08e66fed1694d9161d253fa163dd86f"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "153986a7370e002f377dd68797e7466c421180c1571e233de2f8ab41c8af4f54"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "aee574e56780ea1709a8b56e02d4ffdd9a3a1deaed61e2eb0701f376a4422e42"
-				},
-				"scheme": "ed25519"
+				}
 			}
 		},
 		"roles": {
@@ -81,7 +76,12 @@
 				"threshold": 1
 			}
 		},
-		"spec_version": "1.0",
-		"version": 4
-	}
+		"consistent_snapshot": false
+	},
+	"signatures": [
+		{
+			"keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
+			"sig": "3004c4b60645c6cca18e33835837a1639eead05355aa549f1d1304a22304e7058a50fb6188fc3617a47248eb7481de7a625f036cc69b53daf04a103b12768401"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-false/3/repository/snapshot.json
+++ b/client/testdata/go-tuf/consistent-snapshot-false/3/repository/snapshot.json
@@ -1,23 +1,23 @@
 {
-	"signatures": [
-		{
-			"keyid": "b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef",
-			"sig": "bb6acd05cd4328a69a227ec24f3f241e3b692dfa04301b3ec682c808f143c94bed361ac5215800189f1b415a05ee1bf8534d452dab8548abe514582b91d0f308"
-		}
-	],
 	"signed": {
 		"_type": "snapshot",
+		"spec_version": "1.0",
+		"version": 4,
 		"expires": "2100-01-01T00:00:00Z",
 		"meta": {
 			"targets.json": {
-				"hashes": {
-					"sha512": "75cc15d5a7c20656e37ece0a339434922fb489cf79f8ddf6a11d8c2a797ba1c7c51da0efaf335b31f9185c1eb9a5bbd074e16d412983a104e3bd33877eeb54c3"
-				},
 				"length": 1191,
+				"hashes": {
+					"sha512": "2bf10fb9469cb5f44ccae3c8dac2f70c19e7c58479f74f21aca7a424774ed7ef43295fff3c05f7cfe457b5832366b64e0550874775e277d7233c060e9f94e140"
+				},
 				"version": 4
 			}
-		},
-		"spec_version": "1.0",
-		"version": 4
-	}
+		}
+	},
+	"signatures": [
+		{
+			"keyid": "b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef",
+			"sig": "c5efdc1b461ae319c991fd1840771d94dfc8a3e655ac233901a27959e9f2c3e7ab61b83e3d674caf9e2a6043e776d7c32a2c36dbf0922f7f08059d08fc26720a"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-false/3/repository/targets.json
+++ b/client/testdata/go-tuf/consistent-snapshot-false/3/repository/targets.json
@@ -1,40 +1,40 @@
 {
+	"signed": {
+		"_type": "targets",
+		"spec_version": "1.0",
+		"version": 4,
+		"expires": "2100-01-01T00:00:00Z",
+		"targets": {
+			"0": {
+				"length": 1,
+				"hashes": {
+					"sha512": "31bca02094eb78126a517b206a88c73cfa9ec6f704c7030d18212cace820f025f00bf0ea68dbf3f3a5436ca63b53bf7bf80ad8d5de7d8359d0b7fed9dbc3ab99"
+				}
+			},
+			"1": {
+				"length": 1,
+				"hashes": {
+					"sha512": "4dff4ea340f0a823f15d3f4f01ab62eae0e5da579ccb851f8db9dfe84c58b2b37b89903a740e1ee172da793a6e79d560e5f7f9bd058a12a280433ed6fa46510a"
+				}
+			},
+			"2": {
+				"length": 1,
+				"hashes": {
+					"sha512": "40b244112641dd78dd4f93b6c9190dd46e0099194d5a44257b7efad6ef9ff4683da1eda0244448cb343aa688f5d3efd7314dafe580ac0bcbf115aeca9e8dc114"
+				}
+			},
+			"3": {
+				"length": 1,
+				"hashes": {
+					"sha512": "3bafbf08882a2d10133093a1b8433f50563b93c14acd05b79028eb1d12799027241450980651994501423a66c276ae26c43b739bc65c4e16b10c3af6c202aebb"
+				}
+			}
+		}
+	},
 	"signatures": [
 		{
 			"keyid": "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1",
 			"sig": "7bfe0a63ee324034807b5341336d9d2d64e9ef3936086577b5bbcc6d021b4656bd6bf14d817bbb3908e4dcb05391d1b4031b527c14d942c2d1e38275d5ff1308"
 		}
-	],
-	"signed": {
-		"_type": "targets",
-		"expires": "2100-01-01T00:00:00Z",
-		"spec_version": "1.0",
-		"targets": {
-			"0": {
-				"hashes": {
-					"sha512": "31bca02094eb78126a517b206a88c73cfa9ec6f704c7030d18212cace820f025f00bf0ea68dbf3f3a5436ca63b53bf7bf80ad8d5de7d8359d0b7fed9dbc3ab99"
-				},
-				"length": 1
-			},
-			"1": {
-				"hashes": {
-					"sha512": "4dff4ea340f0a823f15d3f4f01ab62eae0e5da579ccb851f8db9dfe84c58b2b37b89903a740e1ee172da793a6e79d560e5f7f9bd058a12a280433ed6fa46510a"
-				},
-				"length": 1
-			},
-			"2": {
-				"hashes": {
-					"sha512": "40b244112641dd78dd4f93b6c9190dd46e0099194d5a44257b7efad6ef9ff4683da1eda0244448cb343aa688f5d3efd7314dafe580ac0bcbf115aeca9e8dc114"
-				},
-				"length": 1
-			},
-			"3": {
-				"hashes": {
-					"sha512": "3bafbf08882a2d10133093a1b8433f50563b93c14acd05b79028eb1d12799027241450980651994501423a66c276ae26c43b739bc65c4e16b10c3af6c202aebb"
-				},
-				"length": 1
-			}
-		},
-		"version": 4
-	}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-false/3/repository/timestamp.json
+++ b/client/testdata/go-tuf/consistent-snapshot-false/3/repository/timestamp.json
@@ -1,23 +1,23 @@
 {
-	"signatures": [
-		{
-			"keyid": "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8",
-			"sig": "40e97ae18e413a3b44f2f1fb19c0ab57303fb39e950a38954a845f4ba1185bae2314e20c1dc5f157f60106c50e546e1d3469fb0b4cf6675810798f84f22cd001"
-		}
-	],
 	"signed": {
 		"_type": "timestamp",
+		"spec_version": "1.0",
+		"version": 4,
 		"expires": "2100-01-01T00:00:00Z",
 		"meta": {
 			"snapshot.json": {
-				"hashes": {
-					"sha512": "e55cb3fd889a759eaad70713f44d226a3b9b55b0e934fb6a1588832661c553d7f1e0cd6a2dfffeccabb5312dc9cf11ea88f34afbabd6fb715742ba60eb62756c"
-				},
 				"length": 618,
+				"hashes": {
+					"sha512": "4ddee1c0c54af1a3dc54897af33c2457525963059c29583e6df65b9b238732070bd8eb470201154f2d2fa5f8bdf37e01a86e6a53c2bcfe0ff302571458c1898d"
+				},
 				"version": 4
 			}
-		},
-		"spec_version": "1.0",
-		"version": 4
-	}
+		}
+	},
+	"signatures": [
+		{
+			"keyid": "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8",
+			"sig": "585cdcc87c23711642449d469df8bedb53a67b65ac75c303d13b7022c8c34c1db70c926e009c2438639af3be1d613f7ce4c7e28020865ad5ad93a5b085a76005"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-false/4/repository/5.root.json
+++ b/client/testdata/go-tuf/consistent-snapshot-false/4/repository/5.root.json
@@ -1,58 +1,53 @@
 {
-	"signatures": [
-		{
-			"keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
-			"sig": "bd2edde6ba4f5cb3a0cc28dca272e2fc0be691575082479f86b82cea4e541a686a0c132c3a7eca231a5782e52e629df92f8f3f89a5b1f57e8b5368986bddfa0e"
-		}
-	],
 	"signed": {
 		"_type": "root",
-		"consistent_snapshot": false,
+		"spec_version": "1.0",
+		"version": 5,
 		"expires": "2100-01-01T00:00:00Z",
 		"keys": {
 			"a8eaf6de5aecfd0a72b60295b1e1cd12f349079ebcbbb63dbe7072f162e85315": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "3ab34b0c2d4eadccaa0f0cf22ced07b552394063a9de2806993d022360dffc76"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "722dbc861813bb5b568524d62083e875c08e66fed1694d9161d253fa163dd86f"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "153986a7370e002f377dd68797e7466c421180c1571e233de2f8ab41c8af4f54"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "aee574e56780ea1709a8b56e02d4ffdd9a3a1deaed61e2eb0701f376a4422e42"
-				},
-				"scheme": "ed25519"
+				}
 			}
 		},
 		"roles": {
@@ -81,7 +76,12 @@
 				"threshold": 1
 			}
 		},
-		"spec_version": "1.0",
-		"version": 5
-	}
+		"consistent_snapshot": false
+	},
+	"signatures": [
+		{
+			"keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
+			"sig": "bd2edde6ba4f5cb3a0cc28dca272e2fc0be691575082479f86b82cea4e541a686a0c132c3a7eca231a5782e52e629df92f8f3f89a5b1f57e8b5368986bddfa0e"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-false/4/repository/root.json
+++ b/client/testdata/go-tuf/consistent-snapshot-false/4/repository/root.json
@@ -1,58 +1,53 @@
 {
-	"signatures": [
-		{
-			"keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
-			"sig": "bd2edde6ba4f5cb3a0cc28dca272e2fc0be691575082479f86b82cea4e541a686a0c132c3a7eca231a5782e52e629df92f8f3f89a5b1f57e8b5368986bddfa0e"
-		}
-	],
 	"signed": {
 		"_type": "root",
-		"consistent_snapshot": false,
+		"spec_version": "1.0",
+		"version": 5,
 		"expires": "2100-01-01T00:00:00Z",
 		"keys": {
 			"a8eaf6de5aecfd0a72b60295b1e1cd12f349079ebcbbb63dbe7072f162e85315": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "3ab34b0c2d4eadccaa0f0cf22ced07b552394063a9de2806993d022360dffc76"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "722dbc861813bb5b568524d62083e875c08e66fed1694d9161d253fa163dd86f"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "153986a7370e002f377dd68797e7466c421180c1571e233de2f8ab41c8af4f54"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "aee574e56780ea1709a8b56e02d4ffdd9a3a1deaed61e2eb0701f376a4422e42"
-				},
-				"scheme": "ed25519"
+				}
 			}
 		},
 		"roles": {
@@ -81,7 +76,12 @@
 				"threshold": 1
 			}
 		},
-		"spec_version": "1.0",
-		"version": 5
-	}
+		"consistent_snapshot": false
+	},
+	"signatures": [
+		{
+			"keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
+			"sig": "bd2edde6ba4f5cb3a0cc28dca272e2fc0be691575082479f86b82cea4e541a686a0c132c3a7eca231a5782e52e629df92f8f3f89a5b1f57e8b5368986bddfa0e"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-false/4/repository/snapshot.json
+++ b/client/testdata/go-tuf/consistent-snapshot-false/4/repository/snapshot.json
@@ -1,23 +1,23 @@
 {
-	"signatures": [
-		{
-			"keyid": "b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef",
-			"sig": "8ce62f94026a58e31a875017e0d10806e19e9541469330cdbfcd9ebfa5f0c317c7eb203256d114307d018400521add578bd2a11c85b5328af3e4efd471b92307"
-		}
-	],
 	"signed": {
 		"_type": "snapshot",
+		"spec_version": "1.0",
+		"version": 5,
 		"expires": "2100-01-01T00:00:00Z",
 		"meta": {
 			"targets.json": {
-				"hashes": {
-					"sha512": "6832a32afe35bb07557081f3a935296cde39c39f6bca65bd068c337743b570818ff6c04a968a40b83228b46d214b44528719babfa3314658df36d4b21b0757ae"
-				},
 				"length": 1392,
+				"hashes": {
+					"sha512": "93146957ab1f54fe1e8687f408c21a19ad6c033518148bb730b7e635e02f96d9297f1edf12ea5f50354cfcb90385eec9f594d04a08ee876c83759e2314ec8b1a"
+				},
 				"version": 5
 			}
-		},
-		"spec_version": "1.0",
-		"version": 5
-	}
+		}
+	},
+	"signatures": [
+		{
+			"keyid": "b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef",
+			"sig": "c9da15fd5b0b359a46503d0a23fa3a4e8e481cb2bdb72d6dbec4852ed6f9d32e186b35071b6ca70ec947e1688458c3476d33991af202b177ffd79ff89955e703"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-false/4/repository/targets.json
+++ b/client/testdata/go-tuf/consistent-snapshot-false/4/repository/targets.json
@@ -1,46 +1,46 @@
 {
+	"signed": {
+		"_type": "targets",
+		"spec_version": "1.0",
+		"version": 5,
+		"expires": "2100-01-01T00:00:00Z",
+		"targets": {
+			"0": {
+				"length": 1,
+				"hashes": {
+					"sha512": "31bca02094eb78126a517b206a88c73cfa9ec6f704c7030d18212cace820f025f00bf0ea68dbf3f3a5436ca63b53bf7bf80ad8d5de7d8359d0b7fed9dbc3ab99"
+				}
+			},
+			"1": {
+				"length": 1,
+				"hashes": {
+					"sha512": "4dff4ea340f0a823f15d3f4f01ab62eae0e5da579ccb851f8db9dfe84c58b2b37b89903a740e1ee172da793a6e79d560e5f7f9bd058a12a280433ed6fa46510a"
+				}
+			},
+			"2": {
+				"length": 1,
+				"hashes": {
+					"sha512": "40b244112641dd78dd4f93b6c9190dd46e0099194d5a44257b7efad6ef9ff4683da1eda0244448cb343aa688f5d3efd7314dafe580ac0bcbf115aeca9e8dc114"
+				}
+			},
+			"3": {
+				"length": 1,
+				"hashes": {
+					"sha512": "3bafbf08882a2d10133093a1b8433f50563b93c14acd05b79028eb1d12799027241450980651994501423a66c276ae26c43b739bc65c4e16b10c3af6c202aebb"
+				}
+			},
+			"4": {
+				"length": 1,
+				"hashes": {
+					"sha512": "a321d8b405e3ef2604959847b36d171eebebc4a8941dc70a4784935a4fca5d5813de84dfa049f06549aa61b20848c1633ce81b675286ea8fb53db240d831c568"
+				}
+			}
+		}
+	},
 	"signatures": [
 		{
 			"keyid": "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1",
 			"sig": "68f2346cdbe045e8558b2ccd86be66e15466955167557c704b51d7163838f670c53ab9247c16a4ed0cd4ecc981a7e2a04a350b01548f97654499d6f9c17c4202"
 		}
-	],
-	"signed": {
-		"_type": "targets",
-		"expires": "2100-01-01T00:00:00Z",
-		"spec_version": "1.0",
-		"targets": {
-			"0": {
-				"hashes": {
-					"sha512": "31bca02094eb78126a517b206a88c73cfa9ec6f704c7030d18212cace820f025f00bf0ea68dbf3f3a5436ca63b53bf7bf80ad8d5de7d8359d0b7fed9dbc3ab99"
-				},
-				"length": 1
-			},
-			"1": {
-				"hashes": {
-					"sha512": "4dff4ea340f0a823f15d3f4f01ab62eae0e5da579ccb851f8db9dfe84c58b2b37b89903a740e1ee172da793a6e79d560e5f7f9bd058a12a280433ed6fa46510a"
-				},
-				"length": 1
-			},
-			"2": {
-				"hashes": {
-					"sha512": "40b244112641dd78dd4f93b6c9190dd46e0099194d5a44257b7efad6ef9ff4683da1eda0244448cb343aa688f5d3efd7314dafe580ac0bcbf115aeca9e8dc114"
-				},
-				"length": 1
-			},
-			"3": {
-				"hashes": {
-					"sha512": "3bafbf08882a2d10133093a1b8433f50563b93c14acd05b79028eb1d12799027241450980651994501423a66c276ae26c43b739bc65c4e16b10c3af6c202aebb"
-				},
-				"length": 1
-			},
-			"4": {
-				"hashes": {
-					"sha512": "a321d8b405e3ef2604959847b36d171eebebc4a8941dc70a4784935a4fca5d5813de84dfa049f06549aa61b20848c1633ce81b675286ea8fb53db240d831c568"
-				},
-				"length": 1
-			}
-		},
-		"version": 5
-	}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-false/4/repository/timestamp.json
+++ b/client/testdata/go-tuf/consistent-snapshot-false/4/repository/timestamp.json
@@ -1,23 +1,23 @@
 {
-	"signatures": [
-		{
-			"keyid": "a8eaf6de5aecfd0a72b60295b1e1cd12f349079ebcbbb63dbe7072f162e85315",
-			"sig": "36fcb1d9c0e69fe2cd472d97835077b30340da0a326d8d20e844f6a1a84fba439c1662150e029032756b98cd9062686216a77a52b78c6641cd57e8f597d1380b"
-		}
-	],
 	"signed": {
 		"_type": "timestamp",
+		"spec_version": "1.0",
+		"version": 5,
 		"expires": "2100-01-01T00:00:00Z",
 		"meta": {
 			"snapshot.json": {
-				"hashes": {
-					"sha512": "1a984612b0f1657b0a6974bf91e9b33c71a84709a6b36aa76dda4aaea1d132fdd3ef5fd777433a31908bec1f1a39984f9dcc72c3ddbf6b8ed92a7c779d080702"
-				},
 				"length": 618,
+				"hashes": {
+					"sha512": "066115510f2f7fbb2f5cb0a1c1d00759161d8a92329e9ce54d4b17c06466b5a4423bb8bcc9e47c0a37db5c7d8d3bc01df10c4ea25605778e788a76e3e9ca1e0e"
+				},
 				"version": 5
 			}
-		},
-		"spec_version": "1.0",
-		"version": 5
-	}
+		}
+	},
+	"signatures": [
+		{
+			"keyid": "a8eaf6de5aecfd0a72b60295b1e1cd12f349079ebcbbb63dbe7072f162e85315",
+			"sig": "84b9e41c93b32eed4bdb6febe70f9bd4db39bbc7f0c7f820f6a078bbb7146df080a9ceaa237303e3f69e49eb33cc63f8ddff8fba8330904f5fe8d7a66f70400e"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-false/5/repository/snapshot.json
+++ b/client/testdata/go-tuf/consistent-snapshot-false/5/repository/snapshot.json
@@ -1,23 +1,23 @@
 {
-	"signatures": [
-		{
-			"keyid": "b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef",
-			"sig": "7ed4b5c650c534154241ee575862730940ecdc61daa4dbbae167aefa2fe2ab47a6dcbccd099ab15630c6ebfd6acdfbacd89f30a6186c791b58a8dc0769bea405"
-		}
-	],
 	"signed": {
 		"_type": "snapshot",
+		"spec_version": "1.0",
+		"version": 6,
 		"expires": "2100-01-01T00:00:00Z",
 		"meta": {
 			"targets.json": {
-				"hashes": {
-					"sha512": "97c2b46ccae4c2338d99819425239796c6647bf242ac64f13ec9347ec38fd8c6a5470756c079e1aaa23a013a8a720440f3128bd6c99f3c9f32492dd829726eee"
-				},
 				"length": 1593,
+				"hashes": {
+					"sha512": "96fa32225e88f9e98db51369fce606039040efc51f098552594132b301228a78c2f2034d059e4d7d6d7bea14ae9862dd8a995056c5f2ed5ff0d6dc09b9da01df"
+				},
 				"version": 6
 			}
-		},
-		"spec_version": "1.0",
-		"version": 6
-	}
+		}
+	},
+	"signatures": [
+		{
+			"keyid": "b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef",
+			"sig": "7da0cd1e09be0b8161a1048e08a645e5c8d1558137b2934418bf4e28d4d380b6df2306f5cc89e87e41e5abf079547a709fccd2548bf00fd5acfe5ad2496d670b"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-false/5/repository/targets.json
+++ b/client/testdata/go-tuf/consistent-snapshot-false/5/repository/targets.json
@@ -1,52 +1,52 @@
 {
+	"signed": {
+		"_type": "targets",
+		"spec_version": "1.0",
+		"version": 6,
+		"expires": "2100-01-01T00:00:00Z",
+		"targets": {
+			"0": {
+				"length": 1,
+				"hashes": {
+					"sha512": "31bca02094eb78126a517b206a88c73cfa9ec6f704c7030d18212cace820f025f00bf0ea68dbf3f3a5436ca63b53bf7bf80ad8d5de7d8359d0b7fed9dbc3ab99"
+				}
+			},
+			"1": {
+				"length": 1,
+				"hashes": {
+					"sha512": "4dff4ea340f0a823f15d3f4f01ab62eae0e5da579ccb851f8db9dfe84c58b2b37b89903a740e1ee172da793a6e79d560e5f7f9bd058a12a280433ed6fa46510a"
+				}
+			},
+			"2": {
+				"length": 1,
+				"hashes": {
+					"sha512": "40b244112641dd78dd4f93b6c9190dd46e0099194d5a44257b7efad6ef9ff4683da1eda0244448cb343aa688f5d3efd7314dafe580ac0bcbf115aeca9e8dc114"
+				}
+			},
+			"3": {
+				"length": 1,
+				"hashes": {
+					"sha512": "3bafbf08882a2d10133093a1b8433f50563b93c14acd05b79028eb1d12799027241450980651994501423a66c276ae26c43b739bc65c4e16b10c3af6c202aebb"
+				}
+			},
+			"4": {
+				"length": 1,
+				"hashes": {
+					"sha512": "a321d8b405e3ef2604959847b36d171eebebc4a8941dc70a4784935a4fca5d5813de84dfa049f06549aa61b20848c1633ce81b675286ea8fb53db240d831c568"
+				}
+			},
+			"5": {
+				"length": 1,
+				"hashes": {
+					"sha512": "06df05371981a237d0ed11472fae7c94c9ac0eff1d05413516710d17b10a4fb6f4517bda4a695f02d0a73dd4db543b4653df28f5d09dab86f92ffb9b86d01e25"
+				}
+			}
+		}
+	},
 	"signatures": [
 		{
 			"keyid": "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1",
 			"sig": "1e80ae84c4badf194e2fd7225c120999d8f628598fa0e994a2ff7cac705ec2f14601a64ba5370fc668f3fb114975dd81c554400d757f41762c4e12eb4db35d02"
 		}
-	],
-	"signed": {
-		"_type": "targets",
-		"expires": "2100-01-01T00:00:00Z",
-		"spec_version": "1.0",
-		"targets": {
-			"0": {
-				"hashes": {
-					"sha512": "31bca02094eb78126a517b206a88c73cfa9ec6f704c7030d18212cace820f025f00bf0ea68dbf3f3a5436ca63b53bf7bf80ad8d5de7d8359d0b7fed9dbc3ab99"
-				},
-				"length": 1
-			},
-			"1": {
-				"hashes": {
-					"sha512": "4dff4ea340f0a823f15d3f4f01ab62eae0e5da579ccb851f8db9dfe84c58b2b37b89903a740e1ee172da793a6e79d560e5f7f9bd058a12a280433ed6fa46510a"
-				},
-				"length": 1
-			},
-			"2": {
-				"hashes": {
-					"sha512": "40b244112641dd78dd4f93b6c9190dd46e0099194d5a44257b7efad6ef9ff4683da1eda0244448cb343aa688f5d3efd7314dafe580ac0bcbf115aeca9e8dc114"
-				},
-				"length": 1
-			},
-			"3": {
-				"hashes": {
-					"sha512": "3bafbf08882a2d10133093a1b8433f50563b93c14acd05b79028eb1d12799027241450980651994501423a66c276ae26c43b739bc65c4e16b10c3af6c202aebb"
-				},
-				"length": 1
-			},
-			"4": {
-				"hashes": {
-					"sha512": "a321d8b405e3ef2604959847b36d171eebebc4a8941dc70a4784935a4fca5d5813de84dfa049f06549aa61b20848c1633ce81b675286ea8fb53db240d831c568"
-				},
-				"length": 1
-			},
-			"5": {
-				"hashes": {
-					"sha512": "06df05371981a237d0ed11472fae7c94c9ac0eff1d05413516710d17b10a4fb6f4517bda4a695f02d0a73dd4db543b4653df28f5d09dab86f92ffb9b86d01e25"
-				},
-				"length": 1
-			}
-		},
-		"version": 6
-	}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-false/5/repository/timestamp.json
+++ b/client/testdata/go-tuf/consistent-snapshot-false/5/repository/timestamp.json
@@ -1,23 +1,23 @@
 {
-	"signatures": [
-		{
-			"keyid": "a8eaf6de5aecfd0a72b60295b1e1cd12f349079ebcbbb63dbe7072f162e85315",
-			"sig": "b90b0eaa68d6fbd0fda91dc5c9c27b5ad33665c4cb92e9dfa06742ba71870cb7fcc72d373970f35525c60523a16bae9720d6964da84f579f50480d7f6b27dc01"
-		}
-	],
 	"signed": {
 		"_type": "timestamp",
+		"spec_version": "1.0",
+		"version": 6,
 		"expires": "2100-01-01T00:00:00Z",
 		"meta": {
 			"snapshot.json": {
-				"hashes": {
-					"sha512": "69fe654899c63eedc38d481b56030c560967d00a5e709d536b89de7d166945bce2d5c91737a7b54eb058fccb11c2f8ea300c2529c94263a1f6bcadddfb709cc7"
-				},
 				"length": 618,
+				"hashes": {
+					"sha512": "7113ee370f6e1b35df7fd8203d27760e8eb8c32195e8a895f140584caff81256ccdf2d03ed43a5efac45ee4f869908cee2275c0f7e6b54969602e0542c9f78f9"
+				},
 				"version": 6
 			}
-		},
-		"spec_version": "1.0",
-		"version": 6
-	}
+		}
+	},
+	"signatures": [
+		{
+			"keyid": "a8eaf6de5aecfd0a72b60295b1e1cd12f349079ebcbbb63dbe7072f162e85315",
+			"sig": "85758e7d1cdbedfd3d363136924a6e7878a2b9b68486ecc65658a29f96b55fcfeeda0f94fcae30fa3ceafc3ef5f82df8c68ad2774b6e4f4ea0e6cdbafdce8e0f"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-true/0/repository/1.root.json
+++ b/client/testdata/go-tuf/consistent-snapshot-true/0/repository/1.root.json
@@ -1,58 +1,53 @@
 {
-	"signatures": [
-		{
-			"keyid": "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add",
-			"sig": "104eb78cba674adfc7ade1d4396c99466a7d4480e50aab89df53117faffd3d4d4ea87833fe6f83b8dc7f6e1e4a62c0329244c6e5f910627772df3c4d61a8900f"
-		}
-	],
 	"signed": {
 		"_type": "root",
-		"consistent_snapshot": true,
+		"spec_version": "1.0",
+		"version": 1,
 		"expires": "2100-01-01T00:00:00Z",
 		"keys": {
 			"289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "d482fa4805a50870aa1356ace6b764f7ab47ed4dc38f49b1a189afa25f179e94"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "62f71f99c788f16bcdc8bb252455e3a690350e4ddea5a6aab1f9a3aaabcf369a"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "bca152214dbfd3e7a1b7a7b3e2cc179fb00520fd7212c8a60ba99f14dfc0e1ca"
-				},
-				"scheme": "ed25519"
+				}
 			}
 		},
 		"roles": {
@@ -81,7 +76,12 @@
 				"threshold": 1
 			}
 		},
-		"spec_version": "1.0",
-		"version": 1
-	}
+		"consistent_snapshot": true
+	},
+	"signatures": [
+		{
+			"keyid": "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add",
+			"sig": "104eb78cba674adfc7ade1d4396c99466a7d4480e50aab89df53117faffd3d4d4ea87833fe6f83b8dc7f6e1e4a62c0329244c6e5f910627772df3c4d61a8900f"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-true/0/repository/1.snapshot.json
+++ b/client/testdata/go-tuf/consistent-snapshot-true/0/repository/1.snapshot.json
@@ -1,23 +1,23 @@
 {
-	"signatures": [
-		{
-			"keyid": "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45",
-			"sig": "3f24a81d61a8f1fbe2bf310a9d8263c7b3a5fc87524b92e00a100ce6d8e0f742c0ef05b017234b0d08c9cf4da4591deb65e6f76340afad722b3db1b25d2e0203"
-		}
-	],
 	"signed": {
 		"_type": "snapshot",
+		"spec_version": "1.0",
+		"version": 1,
 		"expires": "2100-01-01T00:00:00Z",
 		"meta": {
 			"targets.json": {
-				"hashes": {
-					"sha512": "e0dd9a3833d117cd7bb6fdaae8923d5bda0661cb242be067813bfec3114d83943230b8bb7fcbf093a15d5840f1ecd969f44d3df13e2045d3fb7d22903fbc1bf5"
-				},
 				"length": 588,
+				"hashes": {
+					"sha512": "2532c645262d3a15db2afc561d9ae75db96c3b42abe8bd994c173e45ea70177bc1b080e211d92b6f244d267dcb0a0bc2fbcd1c2b008881c19f950c5e8c0035ec"
+				},
 				"version": 1
 			}
-		},
-		"spec_version": "1.0",
-		"version": 1
-	}
+		}
+	},
+	"signatures": [
+		{
+			"keyid": "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45",
+			"sig": "6efc0efbc7a3b849a58e9cb394af10fe6d199d2ead18e6931932c85f44269d5d73e8f18808d0d9b66fbfd9926b0bda9d2d26a7508a960758c0b84eb8aa31ac0b"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-true/0/repository/1.targets.json
+++ b/client/testdata/go-tuf/consistent-snapshot-true/0/repository/1.targets.json
@@ -1,22 +1,22 @@
 {
+	"signed": {
+		"_type": "targets",
+		"spec_version": "1.0",
+		"version": 1,
+		"expires": "2100-01-01T00:00:00Z",
+		"targets": {
+			"0": {
+				"length": 1,
+				"hashes": {
+					"sha512": "31bca02094eb78126a517b206a88c73cfa9ec6f704c7030d18212cace820f025f00bf0ea68dbf3f3a5436ca63b53bf7bf80ad8d5de7d8359d0b7fed9dbc3ab99"
+				}
+			}
+		}
+	},
 	"signatures": [
 		{
 			"keyid": "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937",
 			"sig": "4d5c3a5da43f3792d077c1128fa28585982ff2957fae59be02a831fc920d0b91cbeaa99fd6c15066ec4da8bf12f993440a90d1624fd7b0a68070e5d60ed2500f"
 		}
-	],
-	"signed": {
-		"_type": "targets",
-		"expires": "2100-01-01T00:00:00Z",
-		"spec_version": "1.0",
-		"targets": {
-			"0": {
-				"hashes": {
-					"sha512": "31bca02094eb78126a517b206a88c73cfa9ec6f704c7030d18212cace820f025f00bf0ea68dbf3f3a5436ca63b53bf7bf80ad8d5de7d8359d0b7fed9dbc3ab99"
-				},
-				"length": 1
-			}
-		},
-		"version": 1
-	}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-true/0/repository/root.json
+++ b/client/testdata/go-tuf/consistent-snapshot-true/0/repository/root.json
@@ -1,58 +1,53 @@
 {
-	"signatures": [
-		{
-			"keyid": "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add",
-			"sig": "104eb78cba674adfc7ade1d4396c99466a7d4480e50aab89df53117faffd3d4d4ea87833fe6f83b8dc7f6e1e4a62c0329244c6e5f910627772df3c4d61a8900f"
-		}
-	],
 	"signed": {
 		"_type": "root",
-		"consistent_snapshot": true,
+		"spec_version": "1.0",
+		"version": 1,
 		"expires": "2100-01-01T00:00:00Z",
 		"keys": {
 			"289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "d482fa4805a50870aa1356ace6b764f7ab47ed4dc38f49b1a189afa25f179e94"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "62f71f99c788f16bcdc8bb252455e3a690350e4ddea5a6aab1f9a3aaabcf369a"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "bca152214dbfd3e7a1b7a7b3e2cc179fb00520fd7212c8a60ba99f14dfc0e1ca"
-				},
-				"scheme": "ed25519"
+				}
 			}
 		},
 		"roles": {
@@ -81,7 +76,12 @@
 				"threshold": 1
 			}
 		},
-		"spec_version": "1.0",
-		"version": 1
-	}
+		"consistent_snapshot": true
+	},
+	"signatures": [
+		{
+			"keyid": "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add",
+			"sig": "104eb78cba674adfc7ade1d4396c99466a7d4480e50aab89df53117faffd3d4d4ea87833fe6f83b8dc7f6e1e4a62c0329244c6e5f910627772df3c4d61a8900f"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-true/0/repository/snapshot.json
+++ b/client/testdata/go-tuf/consistent-snapshot-true/0/repository/snapshot.json
@@ -1,23 +1,23 @@
 {
-	"signatures": [
-		{
-			"keyid": "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45",
-			"sig": "3f24a81d61a8f1fbe2bf310a9d8263c7b3a5fc87524b92e00a100ce6d8e0f742c0ef05b017234b0d08c9cf4da4591deb65e6f76340afad722b3db1b25d2e0203"
-		}
-	],
 	"signed": {
 		"_type": "snapshot",
+		"spec_version": "1.0",
+		"version": 1,
 		"expires": "2100-01-01T00:00:00Z",
 		"meta": {
 			"targets.json": {
-				"hashes": {
-					"sha512": "e0dd9a3833d117cd7bb6fdaae8923d5bda0661cb242be067813bfec3114d83943230b8bb7fcbf093a15d5840f1ecd969f44d3df13e2045d3fb7d22903fbc1bf5"
-				},
 				"length": 588,
+				"hashes": {
+					"sha512": "2532c645262d3a15db2afc561d9ae75db96c3b42abe8bd994c173e45ea70177bc1b080e211d92b6f244d267dcb0a0bc2fbcd1c2b008881c19f950c5e8c0035ec"
+				},
 				"version": 1
 			}
-		},
-		"spec_version": "1.0",
-		"version": 1
-	}
+		}
+	},
+	"signatures": [
+		{
+			"keyid": "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45",
+			"sig": "6efc0efbc7a3b849a58e9cb394af10fe6d199d2ead18e6931932c85f44269d5d73e8f18808d0d9b66fbfd9926b0bda9d2d26a7508a960758c0b84eb8aa31ac0b"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-true/0/repository/targets.json
+++ b/client/testdata/go-tuf/consistent-snapshot-true/0/repository/targets.json
@@ -1,22 +1,22 @@
 {
+	"signed": {
+		"_type": "targets",
+		"spec_version": "1.0",
+		"version": 1,
+		"expires": "2100-01-01T00:00:00Z",
+		"targets": {
+			"0": {
+				"length": 1,
+				"hashes": {
+					"sha512": "31bca02094eb78126a517b206a88c73cfa9ec6f704c7030d18212cace820f025f00bf0ea68dbf3f3a5436ca63b53bf7bf80ad8d5de7d8359d0b7fed9dbc3ab99"
+				}
+			}
+		}
+	},
 	"signatures": [
 		{
 			"keyid": "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937",
 			"sig": "4d5c3a5da43f3792d077c1128fa28585982ff2957fae59be02a831fc920d0b91cbeaa99fd6c15066ec4da8bf12f993440a90d1624fd7b0a68070e5d60ed2500f"
 		}
-	],
-	"signed": {
-		"_type": "targets",
-		"expires": "2100-01-01T00:00:00Z",
-		"spec_version": "1.0",
-		"targets": {
-			"0": {
-				"hashes": {
-					"sha512": "31bca02094eb78126a517b206a88c73cfa9ec6f704c7030d18212cace820f025f00bf0ea68dbf3f3a5436ca63b53bf7bf80ad8d5de7d8359d0b7fed9dbc3ab99"
-				},
-				"length": 1
-			}
-		},
-		"version": 1
-	}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-true/0/repository/timestamp.json
+++ b/client/testdata/go-tuf/consistent-snapshot-true/0/repository/timestamp.json
@@ -1,23 +1,23 @@
 {
-	"signatures": [
-		{
-			"keyid": "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8",
-			"sig": "cc163b290f68c6d41fbc7ca01a30416a43a5ee7652d2f99aff3c6ef01e5c2fa9d5f2caf0e745abeee3baa277ddfe43ac636149963cf085686345addc9e000301"
-		}
-	],
 	"signed": {
 		"_type": "timestamp",
+		"spec_version": "1.0",
+		"version": 1,
 		"expires": "2100-01-01T00:00:00Z",
 		"meta": {
 			"snapshot.json": {
-				"hashes": {
-					"sha512": "973d23a7e47e1003cd4f8c0e431b080171408e488084fe736b664433d9be76e1f1048ea76607c1f485f1dcb23ce2b4980257431c39cee0fddcc53559997cd565"
-				},
 				"length": 617,
+				"hashes": {
+					"sha512": "6fd318e2cc3bca35d2f597e504c095137263ffe3e72f5e5c64e6c7860bea1207448c8994066ffc1cf20898a9d1586cdf09be4e3ea06f69593ed5c7d772f8dfd1"
+				},
 				"version": 1
 			}
-		},
-		"spec_version": "1.0",
-		"version": 1
-	}
+		}
+	},
+	"signatures": [
+		{
+			"keyid": "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8",
+			"sig": "943b219ab6c651793da08d8cf38c7d25fb959c75161b5b86562983841433f9f38c237bb87cf6ecfbb3cb7c78113a3ed2651ee57d3515e7edfc3bebbf349f2809"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-true/1/repository/2.root.json
+++ b/client/testdata/go-tuf/consistent-snapshot-true/1/repository/2.root.json
@@ -1,62 +1,53 @@
 {
-	"signatures": [
-		{
-			"keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
-			"sig": "7ac71619b21fe3a076fbbf3e17f92177c5374f005c32f1818e7c92eee107e3c726ccf906e800878035a9caf7679610147d72cb515cd76164b08b5c8bf93c0f0e"
-		},
-		{
-			"keyid": "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add",
-			"sig": "e560f386c0c270bb44cedda965ad21526e65162b41a2c30d84fb3a80f58913432e8dc74e5e7b0635ccdf51a2b951dae3b0ba28b4aac4088641a2b2cd2933dd04"
-		}
-	],
 	"signed": {
 		"_type": "root",
-		"consistent_snapshot": true,
+		"spec_version": "1.0",
+		"version": 2,
 		"expires": "2100-01-01T00:00:00Z",
 		"keys": {
 			"289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "d482fa4805a50870aa1356ace6b764f7ab47ed4dc38f49b1a189afa25f179e94"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "62f71f99c788f16bcdc8bb252455e3a690350e4ddea5a6aab1f9a3aaabcf369a"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "153986a7370e002f377dd68797e7466c421180c1571e233de2f8ab41c8af4f54"
-				},
-				"scheme": "ed25519"
+				}
 			}
 		},
 		"roles": {
@@ -85,7 +76,16 @@
 				"threshold": 1
 			}
 		},
-		"spec_version": "1.0",
-		"version": 2
-	}
+		"consistent_snapshot": true
+	},
+	"signatures": [
+		{
+			"keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
+			"sig": "7ac71619b21fe3a076fbbf3e17f92177c5374f005c32f1818e7c92eee107e3c726ccf906e800878035a9caf7679610147d72cb515cd76164b08b5c8bf93c0f0e"
+		},
+		{
+			"keyid": "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add",
+			"sig": "e560f386c0c270bb44cedda965ad21526e65162b41a2c30d84fb3a80f58913432e8dc74e5e7b0635ccdf51a2b951dae3b0ba28b4aac4088641a2b2cd2933dd04"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-true/1/repository/2.snapshot.json
+++ b/client/testdata/go-tuf/consistent-snapshot-true/1/repository/2.snapshot.json
@@ -1,23 +1,23 @@
 {
-	"signatures": [
-		{
-			"keyid": "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45",
-			"sig": "bded36f9992b8eb9444a276b397db2ce5f06a8be1273d7f84391b2a098778522a1c49185b2fc858aa99bc69fe820f2444bc8e5077f447ddcf42515c3a7026e0a"
-		}
-	],
 	"signed": {
 		"_type": "snapshot",
+		"spec_version": "1.0",
+		"version": 2,
 		"expires": "2100-01-01T00:00:00Z",
 		"meta": {
 			"targets.json": {
-				"hashes": {
-					"sha512": "8672c435a53519972738fada6ed3b7fa37b3ea42b4fa1e436b774e697a8d696d9efbeb6c590a6e16dec0a5e7f789da82ea59a68fae63f343340d1549a075ab1b"
-				},
 				"length": 789,
+				"hashes": {
+					"sha512": "7a919ed2a5fb7cf80252c9307ac4d27bc2ab54f9bb803389977dcc3d09ae7dff533639c1b19a810d2b212a5c5e904e0f73ab01324ba79dffbb9f7488204caf2a"
+				},
 				"version": 2
 			}
-		},
-		"spec_version": "1.0",
-		"version": 2
-	}
+		}
+	},
+	"signatures": [
+		{
+			"keyid": "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45",
+			"sig": "9a3734441c38daa3275ba60a2178b8dfe5f98296f408bf434144b4bd4f68af73b7f6860e6f2e638b93144ac5bebe361642bbff66a1195596bb8c841429b34508"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-true/1/repository/2.targets.json
+++ b/client/testdata/go-tuf/consistent-snapshot-true/1/repository/2.targets.json
@@ -1,28 +1,28 @@
 {
+	"signed": {
+		"_type": "targets",
+		"spec_version": "1.0",
+		"version": 2,
+		"expires": "2100-01-01T00:00:00Z",
+		"targets": {
+			"0": {
+				"length": 1,
+				"hashes": {
+					"sha512": "31bca02094eb78126a517b206a88c73cfa9ec6f704c7030d18212cace820f025f00bf0ea68dbf3f3a5436ca63b53bf7bf80ad8d5de7d8359d0b7fed9dbc3ab99"
+				}
+			},
+			"1": {
+				"length": 1,
+				"hashes": {
+					"sha512": "4dff4ea340f0a823f15d3f4f01ab62eae0e5da579ccb851f8db9dfe84c58b2b37b89903a740e1ee172da793a6e79d560e5f7f9bd058a12a280433ed6fa46510a"
+				}
+			}
+		}
+	},
 	"signatures": [
 		{
 			"keyid": "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937",
 			"sig": "81bcf5921834a20b8b0946815ad4316f43ffce20b3793e6653dc5fd4b98f1c6318ce2243948574e82414a102717a6f2d731250b3191c54abc8391fd867503e0b"
 		}
-	],
-	"signed": {
-		"_type": "targets",
-		"expires": "2100-01-01T00:00:00Z",
-		"spec_version": "1.0",
-		"targets": {
-			"0": {
-				"hashes": {
-					"sha512": "31bca02094eb78126a517b206a88c73cfa9ec6f704c7030d18212cace820f025f00bf0ea68dbf3f3a5436ca63b53bf7bf80ad8d5de7d8359d0b7fed9dbc3ab99"
-				},
-				"length": 1
-			},
-			"1": {
-				"hashes": {
-					"sha512": "4dff4ea340f0a823f15d3f4f01ab62eae0e5da579ccb851f8db9dfe84c58b2b37b89903a740e1ee172da793a6e79d560e5f7f9bd058a12a280433ed6fa46510a"
-				},
-				"length": 1
-			}
-		},
-		"version": 2
-	}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-true/1/repository/root.json
+++ b/client/testdata/go-tuf/consistent-snapshot-true/1/repository/root.json
@@ -1,62 +1,53 @@
 {
-	"signatures": [
-		{
-			"keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
-			"sig": "7ac71619b21fe3a076fbbf3e17f92177c5374f005c32f1818e7c92eee107e3c726ccf906e800878035a9caf7679610147d72cb515cd76164b08b5c8bf93c0f0e"
-		},
-		{
-			"keyid": "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add",
-			"sig": "e560f386c0c270bb44cedda965ad21526e65162b41a2c30d84fb3a80f58913432e8dc74e5e7b0635ccdf51a2b951dae3b0ba28b4aac4088641a2b2cd2933dd04"
-		}
-	],
 	"signed": {
 		"_type": "root",
-		"consistent_snapshot": true,
+		"spec_version": "1.0",
+		"version": 2,
 		"expires": "2100-01-01T00:00:00Z",
 		"keys": {
 			"289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "d482fa4805a50870aa1356ace6b764f7ab47ed4dc38f49b1a189afa25f179e94"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "62f71f99c788f16bcdc8bb252455e3a690350e4ddea5a6aab1f9a3aaabcf369a"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "153986a7370e002f377dd68797e7466c421180c1571e233de2f8ab41c8af4f54"
-				},
-				"scheme": "ed25519"
+				}
 			}
 		},
 		"roles": {
@@ -85,7 +76,16 @@
 				"threshold": 1
 			}
 		},
-		"spec_version": "1.0",
-		"version": 2
-	}
+		"consistent_snapshot": true
+	},
+	"signatures": [
+		{
+			"keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
+			"sig": "7ac71619b21fe3a076fbbf3e17f92177c5374f005c32f1818e7c92eee107e3c726ccf906e800878035a9caf7679610147d72cb515cd76164b08b5c8bf93c0f0e"
+		},
+		{
+			"keyid": "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add",
+			"sig": "e560f386c0c270bb44cedda965ad21526e65162b41a2c30d84fb3a80f58913432e8dc74e5e7b0635ccdf51a2b951dae3b0ba28b4aac4088641a2b2cd2933dd04"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-true/1/repository/snapshot.json
+++ b/client/testdata/go-tuf/consistent-snapshot-true/1/repository/snapshot.json
@@ -1,23 +1,23 @@
 {
-	"signatures": [
-		{
-			"keyid": "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45",
-			"sig": "bded36f9992b8eb9444a276b397db2ce5f06a8be1273d7f84391b2a098778522a1c49185b2fc858aa99bc69fe820f2444bc8e5077f447ddcf42515c3a7026e0a"
-		}
-	],
 	"signed": {
 		"_type": "snapshot",
+		"spec_version": "1.0",
+		"version": 2,
 		"expires": "2100-01-01T00:00:00Z",
 		"meta": {
 			"targets.json": {
-				"hashes": {
-					"sha512": "8672c435a53519972738fada6ed3b7fa37b3ea42b4fa1e436b774e697a8d696d9efbeb6c590a6e16dec0a5e7f789da82ea59a68fae63f343340d1549a075ab1b"
-				},
 				"length": 789,
+				"hashes": {
+					"sha512": "7a919ed2a5fb7cf80252c9307ac4d27bc2ab54f9bb803389977dcc3d09ae7dff533639c1b19a810d2b212a5c5e904e0f73ab01324ba79dffbb9f7488204caf2a"
+				},
 				"version": 2
 			}
-		},
-		"spec_version": "1.0",
-		"version": 2
-	}
+		}
+	},
+	"signatures": [
+		{
+			"keyid": "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45",
+			"sig": "9a3734441c38daa3275ba60a2178b8dfe5f98296f408bf434144b4bd4f68af73b7f6860e6f2e638b93144ac5bebe361642bbff66a1195596bb8c841429b34508"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-true/1/repository/targets.json
+++ b/client/testdata/go-tuf/consistent-snapshot-true/1/repository/targets.json
@@ -1,28 +1,28 @@
 {
+	"signed": {
+		"_type": "targets",
+		"spec_version": "1.0",
+		"version": 2,
+		"expires": "2100-01-01T00:00:00Z",
+		"targets": {
+			"0": {
+				"length": 1,
+				"hashes": {
+					"sha512": "31bca02094eb78126a517b206a88c73cfa9ec6f704c7030d18212cace820f025f00bf0ea68dbf3f3a5436ca63b53bf7bf80ad8d5de7d8359d0b7fed9dbc3ab99"
+				}
+			},
+			"1": {
+				"length": 1,
+				"hashes": {
+					"sha512": "4dff4ea340f0a823f15d3f4f01ab62eae0e5da579ccb851f8db9dfe84c58b2b37b89903a740e1ee172da793a6e79d560e5f7f9bd058a12a280433ed6fa46510a"
+				}
+			}
+		}
+	},
 	"signatures": [
 		{
 			"keyid": "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937",
 			"sig": "81bcf5921834a20b8b0946815ad4316f43ffce20b3793e6653dc5fd4b98f1c6318ce2243948574e82414a102717a6f2d731250b3191c54abc8391fd867503e0b"
 		}
-	],
-	"signed": {
-		"_type": "targets",
-		"expires": "2100-01-01T00:00:00Z",
-		"spec_version": "1.0",
-		"targets": {
-			"0": {
-				"hashes": {
-					"sha512": "31bca02094eb78126a517b206a88c73cfa9ec6f704c7030d18212cace820f025f00bf0ea68dbf3f3a5436ca63b53bf7bf80ad8d5de7d8359d0b7fed9dbc3ab99"
-				},
-				"length": 1
-			},
-			"1": {
-				"hashes": {
-					"sha512": "4dff4ea340f0a823f15d3f4f01ab62eae0e5da579ccb851f8db9dfe84c58b2b37b89903a740e1ee172da793a6e79d560e5f7f9bd058a12a280433ed6fa46510a"
-				},
-				"length": 1
-			}
-		},
-		"version": 2
-	}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-true/1/repository/timestamp.json
+++ b/client/testdata/go-tuf/consistent-snapshot-true/1/repository/timestamp.json
@@ -1,23 +1,23 @@
 {
-	"signatures": [
-		{
-			"keyid": "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8",
-			"sig": "8ab93c7453677374d1483c495b49d80128b589ca80c1f3e7806bb3c40bd8be793c6df492ce68b2bcf5d50af73fdf7694b0484093b31577720898d6882ae97d0f"
-		}
-	],
 	"signed": {
 		"_type": "timestamp",
+		"spec_version": "1.0",
+		"version": 2,
 		"expires": "2100-01-01T00:00:00Z",
 		"meta": {
 			"snapshot.json": {
-				"hashes": {
-					"sha512": "957e34523e34c2316a9fd02744162834382101796efca153e35028eb1e3fe970427d4e60e375300d1ac92e1c0a8ec74a1b5575a29d337b3454083a76cb922959"
-				},
 				"length": 617,
+				"hashes": {
+					"sha512": "d7204efe9ded4f18d679d75054f43b02b20d74189ea81ad90a67399a8884a810e380a4d343e284c4b6fde506e22a464038871d06950166548a84a76344e2bf3a"
+				},
 				"version": 2
 			}
-		},
-		"spec_version": "1.0",
-		"version": 2
-	}
+		}
+	},
+	"signatures": [
+		{
+			"keyid": "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8",
+			"sig": "85c5afdd9dd3777d2cb31721519ab2942edffc9e1282b65b2cede505a469051ac5e86388461db49f948a5998b132dddb5ce0156d21622a6d2201fb93322de20f"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-true/2/repository/3.root.json
+++ b/client/testdata/go-tuf/consistent-snapshot-true/2/repository/3.root.json
@@ -1,58 +1,53 @@
 {
-	"signatures": [
-		{
-			"keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
-			"sig": "475436056dca79fd151ae830ad2f4dbc7ecc5b146a79319c20a1167d4f214047d8f3847d1cda4ccd32a48acb13acbea55ba7e8254cffaa07e3de9ecdd0c13d03"
-		}
-	],
 	"signed": {
 		"_type": "root",
-		"consistent_snapshot": true,
+		"spec_version": "1.0",
+		"version": 3,
 		"expires": "2100-01-01T00:00:00Z",
 		"keys": {
 			"289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "d482fa4805a50870aa1356ace6b764f7ab47ed4dc38f49b1a189afa25f179e94"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "153986a7370e002f377dd68797e7466c421180c1571e233de2f8ab41c8af4f54"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "aee574e56780ea1709a8b56e02d4ffdd9a3a1deaed61e2eb0701f376a4422e42"
-				},
-				"scheme": "ed25519"
+				}
 			}
 		},
 		"roles": {
@@ -81,7 +76,12 @@
 				"threshold": 1
 			}
 		},
-		"spec_version": "1.0",
-		"version": 3
-	}
+		"consistent_snapshot": true
+	},
+	"signatures": [
+		{
+			"keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
+			"sig": "475436056dca79fd151ae830ad2f4dbc7ecc5b146a79319c20a1167d4f214047d8f3847d1cda4ccd32a48acb13acbea55ba7e8254cffaa07e3de9ecdd0c13d03"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-true/2/repository/3.snapshot.json
+++ b/client/testdata/go-tuf/consistent-snapshot-true/2/repository/3.snapshot.json
@@ -1,23 +1,23 @@
 {
-	"signatures": [
-		{
-			"keyid": "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45",
-			"sig": "94a60aaddf390953b997b783bab689a2cbaf66610b4dee5645ef858480f709b61afefc5eb21c6131aa5d3e2248eccebe77a7b4a8462f6f8f7964680085053903"
-		}
-	],
 	"signed": {
 		"_type": "snapshot",
+		"spec_version": "1.0",
+		"version": 3,
 		"expires": "2100-01-01T00:00:00Z",
 		"meta": {
 			"targets.json": {
-				"hashes": {
-					"sha512": "b103f5cd1d68e0b5f7b96af03a27cf971460977976cff0b1d1371dcce6d45ef78e183fa26bf886f3864e84b8ddbbfc1bab7bd0e2be180ad82ed26f22a8e9b68b"
-				},
 				"length": 990,
+				"hashes": {
+					"sha512": "987022c23793b3d234d422c3ed4525f8c3771887db610fb2e7d6b455d27ad8b1b4a957a699d519c03754fe4feeb387ec84c95e1edac1d4e9b186bfbdff76ad10"
+				},
 				"version": 3
 			}
-		},
-		"spec_version": "1.0",
-		"version": 3
-	}
+		}
+	},
+	"signatures": [
+		{
+			"keyid": "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45",
+			"sig": "31896c9165a37aa54cf1c4d5f936035e092b1cf4c233ef35cd12c987aaa02de7ec99f26c198984fe0dcc21765d096b25cd67e7ca058613b2b2abef3193dd880d"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-true/2/repository/3.targets.json
+++ b/client/testdata/go-tuf/consistent-snapshot-true/2/repository/3.targets.json
@@ -1,34 +1,34 @@
 {
+	"signed": {
+		"_type": "targets",
+		"spec_version": "1.0",
+		"version": 3,
+		"expires": "2100-01-01T00:00:00Z",
+		"targets": {
+			"0": {
+				"length": 1,
+				"hashes": {
+					"sha512": "31bca02094eb78126a517b206a88c73cfa9ec6f704c7030d18212cace820f025f00bf0ea68dbf3f3a5436ca63b53bf7bf80ad8d5de7d8359d0b7fed9dbc3ab99"
+				}
+			},
+			"1": {
+				"length": 1,
+				"hashes": {
+					"sha512": "4dff4ea340f0a823f15d3f4f01ab62eae0e5da579ccb851f8db9dfe84c58b2b37b89903a740e1ee172da793a6e79d560e5f7f9bd058a12a280433ed6fa46510a"
+				}
+			},
+			"2": {
+				"length": 1,
+				"hashes": {
+					"sha512": "40b244112641dd78dd4f93b6c9190dd46e0099194d5a44257b7efad6ef9ff4683da1eda0244448cb343aa688f5d3efd7314dafe580ac0bcbf115aeca9e8dc114"
+				}
+			}
+		}
+	},
 	"signatures": [
 		{
 			"keyid": "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1",
 			"sig": "09593c7b47f4dbf1e8ac949fa010279ffbbd36070a54a89b689378441e8111602d4236fa2962063778c82027d4746a8973ba8fea86e9c105190da9fa362d8b0c"
 		}
-	],
-	"signed": {
-		"_type": "targets",
-		"expires": "2100-01-01T00:00:00Z",
-		"spec_version": "1.0",
-		"targets": {
-			"0": {
-				"hashes": {
-					"sha512": "31bca02094eb78126a517b206a88c73cfa9ec6f704c7030d18212cace820f025f00bf0ea68dbf3f3a5436ca63b53bf7bf80ad8d5de7d8359d0b7fed9dbc3ab99"
-				},
-				"length": 1
-			},
-			"1": {
-				"hashes": {
-					"sha512": "4dff4ea340f0a823f15d3f4f01ab62eae0e5da579ccb851f8db9dfe84c58b2b37b89903a740e1ee172da793a6e79d560e5f7f9bd058a12a280433ed6fa46510a"
-				},
-				"length": 1
-			},
-			"2": {
-				"hashes": {
-					"sha512": "40b244112641dd78dd4f93b6c9190dd46e0099194d5a44257b7efad6ef9ff4683da1eda0244448cb343aa688f5d3efd7314dafe580ac0bcbf115aeca9e8dc114"
-				},
-				"length": 1
-			}
-		},
-		"version": 3
-	}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-true/2/repository/root.json
+++ b/client/testdata/go-tuf/consistent-snapshot-true/2/repository/root.json
@@ -1,58 +1,53 @@
 {
-	"signatures": [
-		{
-			"keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
-			"sig": "475436056dca79fd151ae830ad2f4dbc7ecc5b146a79319c20a1167d4f214047d8f3847d1cda4ccd32a48acb13acbea55ba7e8254cffaa07e3de9ecdd0c13d03"
-		}
-	],
 	"signed": {
 		"_type": "root",
-		"consistent_snapshot": true,
+		"spec_version": "1.0",
+		"version": 3,
 		"expires": "2100-01-01T00:00:00Z",
 		"keys": {
 			"289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "d482fa4805a50870aa1356ace6b764f7ab47ed4dc38f49b1a189afa25f179e94"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "153986a7370e002f377dd68797e7466c421180c1571e233de2f8ab41c8af4f54"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "aee574e56780ea1709a8b56e02d4ffdd9a3a1deaed61e2eb0701f376a4422e42"
-				},
-				"scheme": "ed25519"
+				}
 			}
 		},
 		"roles": {
@@ -81,7 +76,12 @@
 				"threshold": 1
 			}
 		},
-		"spec_version": "1.0",
-		"version": 3
-	}
+		"consistent_snapshot": true
+	},
+	"signatures": [
+		{
+			"keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
+			"sig": "475436056dca79fd151ae830ad2f4dbc7ecc5b146a79319c20a1167d4f214047d8f3847d1cda4ccd32a48acb13acbea55ba7e8254cffaa07e3de9ecdd0c13d03"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-true/2/repository/snapshot.json
+++ b/client/testdata/go-tuf/consistent-snapshot-true/2/repository/snapshot.json
@@ -1,23 +1,23 @@
 {
-	"signatures": [
-		{
-			"keyid": "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45",
-			"sig": "94a60aaddf390953b997b783bab689a2cbaf66610b4dee5645ef858480f709b61afefc5eb21c6131aa5d3e2248eccebe77a7b4a8462f6f8f7964680085053903"
-		}
-	],
 	"signed": {
 		"_type": "snapshot",
+		"spec_version": "1.0",
+		"version": 3,
 		"expires": "2100-01-01T00:00:00Z",
 		"meta": {
 			"targets.json": {
-				"hashes": {
-					"sha512": "b103f5cd1d68e0b5f7b96af03a27cf971460977976cff0b1d1371dcce6d45ef78e183fa26bf886f3864e84b8ddbbfc1bab7bd0e2be180ad82ed26f22a8e9b68b"
-				},
 				"length": 990,
+				"hashes": {
+					"sha512": "987022c23793b3d234d422c3ed4525f8c3771887db610fb2e7d6b455d27ad8b1b4a957a699d519c03754fe4feeb387ec84c95e1edac1d4e9b186bfbdff76ad10"
+				},
 				"version": 3
 			}
-		},
-		"spec_version": "1.0",
-		"version": 3
-	}
+		}
+	},
+	"signatures": [
+		{
+			"keyid": "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45",
+			"sig": "31896c9165a37aa54cf1c4d5f936035e092b1cf4c233ef35cd12c987aaa02de7ec99f26c198984fe0dcc21765d096b25cd67e7ca058613b2b2abef3193dd880d"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-true/2/repository/targets.json
+++ b/client/testdata/go-tuf/consistent-snapshot-true/2/repository/targets.json
@@ -1,34 +1,34 @@
 {
+	"signed": {
+		"_type": "targets",
+		"spec_version": "1.0",
+		"version": 3,
+		"expires": "2100-01-01T00:00:00Z",
+		"targets": {
+			"0": {
+				"length": 1,
+				"hashes": {
+					"sha512": "31bca02094eb78126a517b206a88c73cfa9ec6f704c7030d18212cace820f025f00bf0ea68dbf3f3a5436ca63b53bf7bf80ad8d5de7d8359d0b7fed9dbc3ab99"
+				}
+			},
+			"1": {
+				"length": 1,
+				"hashes": {
+					"sha512": "4dff4ea340f0a823f15d3f4f01ab62eae0e5da579ccb851f8db9dfe84c58b2b37b89903a740e1ee172da793a6e79d560e5f7f9bd058a12a280433ed6fa46510a"
+				}
+			},
+			"2": {
+				"length": 1,
+				"hashes": {
+					"sha512": "40b244112641dd78dd4f93b6c9190dd46e0099194d5a44257b7efad6ef9ff4683da1eda0244448cb343aa688f5d3efd7314dafe580ac0bcbf115aeca9e8dc114"
+				}
+			}
+		}
+	},
 	"signatures": [
 		{
 			"keyid": "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1",
 			"sig": "09593c7b47f4dbf1e8ac949fa010279ffbbd36070a54a89b689378441e8111602d4236fa2962063778c82027d4746a8973ba8fea86e9c105190da9fa362d8b0c"
 		}
-	],
-	"signed": {
-		"_type": "targets",
-		"expires": "2100-01-01T00:00:00Z",
-		"spec_version": "1.0",
-		"targets": {
-			"0": {
-				"hashes": {
-					"sha512": "31bca02094eb78126a517b206a88c73cfa9ec6f704c7030d18212cace820f025f00bf0ea68dbf3f3a5436ca63b53bf7bf80ad8d5de7d8359d0b7fed9dbc3ab99"
-				},
-				"length": 1
-			},
-			"1": {
-				"hashes": {
-					"sha512": "4dff4ea340f0a823f15d3f4f01ab62eae0e5da579ccb851f8db9dfe84c58b2b37b89903a740e1ee172da793a6e79d560e5f7f9bd058a12a280433ed6fa46510a"
-				},
-				"length": 1
-			},
-			"2": {
-				"hashes": {
-					"sha512": "40b244112641dd78dd4f93b6c9190dd46e0099194d5a44257b7efad6ef9ff4683da1eda0244448cb343aa688f5d3efd7314dafe580ac0bcbf115aeca9e8dc114"
-				},
-				"length": 1
-			}
-		},
-		"version": 3
-	}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-true/2/repository/timestamp.json
+++ b/client/testdata/go-tuf/consistent-snapshot-true/2/repository/timestamp.json
@@ -1,23 +1,23 @@
 {
-	"signatures": [
-		{
-			"keyid": "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8",
-			"sig": "e431037f03bb3e323aa6d9f97533883a0d111698a17cd7eb7843961fa4b15a12a98a8a6cac377df934a9303d3765cc5314f59a160ffe11a32e76c18c27b0180f"
-		}
-	],
 	"signed": {
 		"_type": "timestamp",
+		"spec_version": "1.0",
+		"version": 3,
 		"expires": "2100-01-01T00:00:00Z",
 		"meta": {
 			"snapshot.json": {
-				"hashes": {
-					"sha512": "49d07f15210a34a0b2bf51e2d349b243bba68800796a6f7031adaa14a86da0f3aa96098c46c6f55330fb71a424a6658cdf09683287f72f9082302e9be3aec1ef"
-				},
 				"length": 617,
+				"hashes": {
+					"sha512": "70d2f64bc810a0ae1c827c28eed47304c3a9c57402447d129aa3ac851d809a48bd0421aaa99e9e49055984e77f221510415cf27aca8f30f4db1767d6b7bd6024"
+				},
 				"version": 3
 			}
-		},
-		"spec_version": "1.0",
-		"version": 3
-	}
+		}
+	},
+	"signatures": [
+		{
+			"keyid": "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8",
+			"sig": "22367ebcf7c5265260b288e9fec6110257b8c8745af25f2b14c5d347ddab94f46893926bdd37c58d142089419708e446c5e3c1af5c47c51187fe69ca95038605"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-true/3/repository/4.root.json
+++ b/client/testdata/go-tuf/consistent-snapshot-true/3/repository/4.root.json
@@ -1,58 +1,53 @@
 {
-	"signatures": [
-		{
-			"keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
-			"sig": "15431a0217deb636e2e79876cfdfc8b78fdda1119e6c8512c7dc61af240a7d2303f172e7fc28de7dfe58d92c84f5118ccd09d0f29f49aaa3f7ef95edf21e2d0a"
-		}
-	],
 	"signed": {
 		"_type": "root",
-		"consistent_snapshot": true,
+		"spec_version": "1.0",
+		"version": 4,
 		"expires": "2100-01-01T00:00:00Z",
 		"keys": {
 			"aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "722dbc861813bb5b568524d62083e875c08e66fed1694d9161d253fa163dd86f"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "153986a7370e002f377dd68797e7466c421180c1571e233de2f8ab41c8af4f54"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "aee574e56780ea1709a8b56e02d4ffdd9a3a1deaed61e2eb0701f376a4422e42"
-				},
-				"scheme": "ed25519"
+				}
 			}
 		},
 		"roles": {
@@ -81,7 +76,12 @@
 				"threshold": 1
 			}
 		},
-		"spec_version": "1.0",
-		"version": 4
-	}
+		"consistent_snapshot": true
+	},
+	"signatures": [
+		{
+			"keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
+			"sig": "15431a0217deb636e2e79876cfdfc8b78fdda1119e6c8512c7dc61af240a7d2303f172e7fc28de7dfe58d92c84f5118ccd09d0f29f49aaa3f7ef95edf21e2d0a"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-true/3/repository/4.snapshot.json
+++ b/client/testdata/go-tuf/consistent-snapshot-true/3/repository/4.snapshot.json
@@ -1,23 +1,23 @@
 {
-	"signatures": [
-		{
-			"keyid": "b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef",
-			"sig": "bb6acd05cd4328a69a227ec24f3f241e3b692dfa04301b3ec682c808f143c94bed361ac5215800189f1b415a05ee1bf8534d452dab8548abe514582b91d0f308"
-		}
-	],
 	"signed": {
 		"_type": "snapshot",
+		"spec_version": "1.0",
+		"version": 4,
 		"expires": "2100-01-01T00:00:00Z",
 		"meta": {
 			"targets.json": {
-				"hashes": {
-					"sha512": "75cc15d5a7c20656e37ece0a339434922fb489cf79f8ddf6a11d8c2a797ba1c7c51da0efaf335b31f9185c1eb9a5bbd074e16d412983a104e3bd33877eeb54c3"
-				},
 				"length": 1191,
+				"hashes": {
+					"sha512": "2bf10fb9469cb5f44ccae3c8dac2f70c19e7c58479f74f21aca7a424774ed7ef43295fff3c05f7cfe457b5832366b64e0550874775e277d7233c060e9f94e140"
+				},
 				"version": 4
 			}
-		},
-		"spec_version": "1.0",
-		"version": 4
-	}
+		}
+	},
+	"signatures": [
+		{
+			"keyid": "b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef",
+			"sig": "c5efdc1b461ae319c991fd1840771d94dfc8a3e655ac233901a27959e9f2c3e7ab61b83e3d674caf9e2a6043e776d7c32a2c36dbf0922f7f08059d08fc26720a"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-true/3/repository/4.targets.json
+++ b/client/testdata/go-tuf/consistent-snapshot-true/3/repository/4.targets.json
@@ -1,40 +1,40 @@
 {
+	"signed": {
+		"_type": "targets",
+		"spec_version": "1.0",
+		"version": 4,
+		"expires": "2100-01-01T00:00:00Z",
+		"targets": {
+			"0": {
+				"length": 1,
+				"hashes": {
+					"sha512": "31bca02094eb78126a517b206a88c73cfa9ec6f704c7030d18212cace820f025f00bf0ea68dbf3f3a5436ca63b53bf7bf80ad8d5de7d8359d0b7fed9dbc3ab99"
+				}
+			},
+			"1": {
+				"length": 1,
+				"hashes": {
+					"sha512": "4dff4ea340f0a823f15d3f4f01ab62eae0e5da579ccb851f8db9dfe84c58b2b37b89903a740e1ee172da793a6e79d560e5f7f9bd058a12a280433ed6fa46510a"
+				}
+			},
+			"2": {
+				"length": 1,
+				"hashes": {
+					"sha512": "40b244112641dd78dd4f93b6c9190dd46e0099194d5a44257b7efad6ef9ff4683da1eda0244448cb343aa688f5d3efd7314dafe580ac0bcbf115aeca9e8dc114"
+				}
+			},
+			"3": {
+				"length": 1,
+				"hashes": {
+					"sha512": "3bafbf08882a2d10133093a1b8433f50563b93c14acd05b79028eb1d12799027241450980651994501423a66c276ae26c43b739bc65c4e16b10c3af6c202aebb"
+				}
+			}
+		}
+	},
 	"signatures": [
 		{
 			"keyid": "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1",
 			"sig": "7bfe0a63ee324034807b5341336d9d2d64e9ef3936086577b5bbcc6d021b4656bd6bf14d817bbb3908e4dcb05391d1b4031b527c14d942c2d1e38275d5ff1308"
 		}
-	],
-	"signed": {
-		"_type": "targets",
-		"expires": "2100-01-01T00:00:00Z",
-		"spec_version": "1.0",
-		"targets": {
-			"0": {
-				"hashes": {
-					"sha512": "31bca02094eb78126a517b206a88c73cfa9ec6f704c7030d18212cace820f025f00bf0ea68dbf3f3a5436ca63b53bf7bf80ad8d5de7d8359d0b7fed9dbc3ab99"
-				},
-				"length": 1
-			},
-			"1": {
-				"hashes": {
-					"sha512": "4dff4ea340f0a823f15d3f4f01ab62eae0e5da579ccb851f8db9dfe84c58b2b37b89903a740e1ee172da793a6e79d560e5f7f9bd058a12a280433ed6fa46510a"
-				},
-				"length": 1
-			},
-			"2": {
-				"hashes": {
-					"sha512": "40b244112641dd78dd4f93b6c9190dd46e0099194d5a44257b7efad6ef9ff4683da1eda0244448cb343aa688f5d3efd7314dafe580ac0bcbf115aeca9e8dc114"
-				},
-				"length": 1
-			},
-			"3": {
-				"hashes": {
-					"sha512": "3bafbf08882a2d10133093a1b8433f50563b93c14acd05b79028eb1d12799027241450980651994501423a66c276ae26c43b739bc65c4e16b10c3af6c202aebb"
-				},
-				"length": 1
-			}
-		},
-		"version": 4
-	}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-true/3/repository/root.json
+++ b/client/testdata/go-tuf/consistent-snapshot-true/3/repository/root.json
@@ -1,58 +1,53 @@
 {
-	"signatures": [
-		{
-			"keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
-			"sig": "15431a0217deb636e2e79876cfdfc8b78fdda1119e6c8512c7dc61af240a7d2303f172e7fc28de7dfe58d92c84f5118ccd09d0f29f49aaa3f7ef95edf21e2d0a"
-		}
-	],
 	"signed": {
 		"_type": "root",
-		"consistent_snapshot": true,
+		"spec_version": "1.0",
+		"version": 4,
 		"expires": "2100-01-01T00:00:00Z",
 		"keys": {
 			"aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "722dbc861813bb5b568524d62083e875c08e66fed1694d9161d253fa163dd86f"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "153986a7370e002f377dd68797e7466c421180c1571e233de2f8ab41c8af4f54"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "aee574e56780ea1709a8b56e02d4ffdd9a3a1deaed61e2eb0701f376a4422e42"
-				},
-				"scheme": "ed25519"
+				}
 			}
 		},
 		"roles": {
@@ -81,7 +76,12 @@
 				"threshold": 1
 			}
 		},
-		"spec_version": "1.0",
-		"version": 4
-	}
+		"consistent_snapshot": true
+	},
+	"signatures": [
+		{
+			"keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
+			"sig": "15431a0217deb636e2e79876cfdfc8b78fdda1119e6c8512c7dc61af240a7d2303f172e7fc28de7dfe58d92c84f5118ccd09d0f29f49aaa3f7ef95edf21e2d0a"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-true/3/repository/snapshot.json
+++ b/client/testdata/go-tuf/consistent-snapshot-true/3/repository/snapshot.json
@@ -1,23 +1,23 @@
 {
-	"signatures": [
-		{
-			"keyid": "b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef",
-			"sig": "bb6acd05cd4328a69a227ec24f3f241e3b692dfa04301b3ec682c808f143c94bed361ac5215800189f1b415a05ee1bf8534d452dab8548abe514582b91d0f308"
-		}
-	],
 	"signed": {
 		"_type": "snapshot",
+		"spec_version": "1.0",
+		"version": 4,
 		"expires": "2100-01-01T00:00:00Z",
 		"meta": {
 			"targets.json": {
-				"hashes": {
-					"sha512": "75cc15d5a7c20656e37ece0a339434922fb489cf79f8ddf6a11d8c2a797ba1c7c51da0efaf335b31f9185c1eb9a5bbd074e16d412983a104e3bd33877eeb54c3"
-				},
 				"length": 1191,
+				"hashes": {
+					"sha512": "2bf10fb9469cb5f44ccae3c8dac2f70c19e7c58479f74f21aca7a424774ed7ef43295fff3c05f7cfe457b5832366b64e0550874775e277d7233c060e9f94e140"
+				},
 				"version": 4
 			}
-		},
-		"spec_version": "1.0",
-		"version": 4
-	}
+		}
+	},
+	"signatures": [
+		{
+			"keyid": "b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef",
+			"sig": "c5efdc1b461ae319c991fd1840771d94dfc8a3e655ac233901a27959e9f2c3e7ab61b83e3d674caf9e2a6043e776d7c32a2c36dbf0922f7f08059d08fc26720a"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-true/3/repository/targets.json
+++ b/client/testdata/go-tuf/consistent-snapshot-true/3/repository/targets.json
@@ -1,40 +1,40 @@
 {
+	"signed": {
+		"_type": "targets",
+		"spec_version": "1.0",
+		"version": 4,
+		"expires": "2100-01-01T00:00:00Z",
+		"targets": {
+			"0": {
+				"length": 1,
+				"hashes": {
+					"sha512": "31bca02094eb78126a517b206a88c73cfa9ec6f704c7030d18212cace820f025f00bf0ea68dbf3f3a5436ca63b53bf7bf80ad8d5de7d8359d0b7fed9dbc3ab99"
+				}
+			},
+			"1": {
+				"length": 1,
+				"hashes": {
+					"sha512": "4dff4ea340f0a823f15d3f4f01ab62eae0e5da579ccb851f8db9dfe84c58b2b37b89903a740e1ee172da793a6e79d560e5f7f9bd058a12a280433ed6fa46510a"
+				}
+			},
+			"2": {
+				"length": 1,
+				"hashes": {
+					"sha512": "40b244112641dd78dd4f93b6c9190dd46e0099194d5a44257b7efad6ef9ff4683da1eda0244448cb343aa688f5d3efd7314dafe580ac0bcbf115aeca9e8dc114"
+				}
+			},
+			"3": {
+				"length": 1,
+				"hashes": {
+					"sha512": "3bafbf08882a2d10133093a1b8433f50563b93c14acd05b79028eb1d12799027241450980651994501423a66c276ae26c43b739bc65c4e16b10c3af6c202aebb"
+				}
+			}
+		}
+	},
 	"signatures": [
 		{
 			"keyid": "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1",
 			"sig": "7bfe0a63ee324034807b5341336d9d2d64e9ef3936086577b5bbcc6d021b4656bd6bf14d817bbb3908e4dcb05391d1b4031b527c14d942c2d1e38275d5ff1308"
 		}
-	],
-	"signed": {
-		"_type": "targets",
-		"expires": "2100-01-01T00:00:00Z",
-		"spec_version": "1.0",
-		"targets": {
-			"0": {
-				"hashes": {
-					"sha512": "31bca02094eb78126a517b206a88c73cfa9ec6f704c7030d18212cace820f025f00bf0ea68dbf3f3a5436ca63b53bf7bf80ad8d5de7d8359d0b7fed9dbc3ab99"
-				},
-				"length": 1
-			},
-			"1": {
-				"hashes": {
-					"sha512": "4dff4ea340f0a823f15d3f4f01ab62eae0e5da579ccb851f8db9dfe84c58b2b37b89903a740e1ee172da793a6e79d560e5f7f9bd058a12a280433ed6fa46510a"
-				},
-				"length": 1
-			},
-			"2": {
-				"hashes": {
-					"sha512": "40b244112641dd78dd4f93b6c9190dd46e0099194d5a44257b7efad6ef9ff4683da1eda0244448cb343aa688f5d3efd7314dafe580ac0bcbf115aeca9e8dc114"
-				},
-				"length": 1
-			},
-			"3": {
-				"hashes": {
-					"sha512": "3bafbf08882a2d10133093a1b8433f50563b93c14acd05b79028eb1d12799027241450980651994501423a66c276ae26c43b739bc65c4e16b10c3af6c202aebb"
-				},
-				"length": 1
-			}
-		},
-		"version": 4
-	}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-true/3/repository/timestamp.json
+++ b/client/testdata/go-tuf/consistent-snapshot-true/3/repository/timestamp.json
@@ -1,23 +1,23 @@
 {
-	"signatures": [
-		{
-			"keyid": "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8",
-			"sig": "40e97ae18e413a3b44f2f1fb19c0ab57303fb39e950a38954a845f4ba1185bae2314e20c1dc5f157f60106c50e546e1d3469fb0b4cf6675810798f84f22cd001"
-		}
-	],
 	"signed": {
 		"_type": "timestamp",
+		"spec_version": "1.0",
+		"version": 4,
 		"expires": "2100-01-01T00:00:00Z",
 		"meta": {
 			"snapshot.json": {
-				"hashes": {
-					"sha512": "e55cb3fd889a759eaad70713f44d226a3b9b55b0e934fb6a1588832661c553d7f1e0cd6a2dfffeccabb5312dc9cf11ea88f34afbabd6fb715742ba60eb62756c"
-				},
 				"length": 618,
+				"hashes": {
+					"sha512": "4ddee1c0c54af1a3dc54897af33c2457525963059c29583e6df65b9b238732070bd8eb470201154f2d2fa5f8bdf37e01a86e6a53c2bcfe0ff302571458c1898d"
+				},
 				"version": 4
 			}
-		},
-		"spec_version": "1.0",
-		"version": 4
-	}
+		}
+	},
+	"signatures": [
+		{
+			"keyid": "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8",
+			"sig": "585cdcc87c23711642449d469df8bedb53a67b65ac75c303d13b7022c8c34c1db70c926e009c2438639af3be1d613f7ce4c7e28020865ad5ad93a5b085a76005"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-true/4/repository/5.root.json
+++ b/client/testdata/go-tuf/consistent-snapshot-true/4/repository/5.root.json
@@ -1,58 +1,53 @@
 {
-	"signatures": [
-		{
-			"keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
-			"sig": "2b6f30258eaf8b4b2d900a2efb4a597b45a9c0c5a0720d5521dd37d63c34d1db62aafaa1d95b6d881f9c991615ab68930c24ef247d2f45836bca3659e36d9c0b"
-		}
-	],
 	"signed": {
 		"_type": "root",
-		"consistent_snapshot": true,
+		"spec_version": "1.0",
+		"version": 5,
 		"expires": "2100-01-01T00:00:00Z",
 		"keys": {
 			"a8eaf6de5aecfd0a72b60295b1e1cd12f349079ebcbbb63dbe7072f162e85315": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "3ab34b0c2d4eadccaa0f0cf22ced07b552394063a9de2806993d022360dffc76"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "722dbc861813bb5b568524d62083e875c08e66fed1694d9161d253fa163dd86f"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "153986a7370e002f377dd68797e7466c421180c1571e233de2f8ab41c8af4f54"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "aee574e56780ea1709a8b56e02d4ffdd9a3a1deaed61e2eb0701f376a4422e42"
-				},
-				"scheme": "ed25519"
+				}
 			}
 		},
 		"roles": {
@@ -81,7 +76,12 @@
 				"threshold": 1
 			}
 		},
-		"spec_version": "1.0",
-		"version": 5
-	}
+		"consistent_snapshot": true
+	},
+	"signatures": [
+		{
+			"keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
+			"sig": "2b6f30258eaf8b4b2d900a2efb4a597b45a9c0c5a0720d5521dd37d63c34d1db62aafaa1d95b6d881f9c991615ab68930c24ef247d2f45836bca3659e36d9c0b"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-true/4/repository/5.snapshot.json
+++ b/client/testdata/go-tuf/consistent-snapshot-true/4/repository/5.snapshot.json
@@ -1,23 +1,23 @@
 {
-	"signatures": [
-		{
-			"keyid": "b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef",
-			"sig": "8ce62f94026a58e31a875017e0d10806e19e9541469330cdbfcd9ebfa5f0c317c7eb203256d114307d018400521add578bd2a11c85b5328af3e4efd471b92307"
-		}
-	],
 	"signed": {
 		"_type": "snapshot",
+		"spec_version": "1.0",
+		"version": 5,
 		"expires": "2100-01-01T00:00:00Z",
 		"meta": {
 			"targets.json": {
-				"hashes": {
-					"sha512": "6832a32afe35bb07557081f3a935296cde39c39f6bca65bd068c337743b570818ff6c04a968a40b83228b46d214b44528719babfa3314658df36d4b21b0757ae"
-				},
 				"length": 1392,
+				"hashes": {
+					"sha512": "93146957ab1f54fe1e8687f408c21a19ad6c033518148bb730b7e635e02f96d9297f1edf12ea5f50354cfcb90385eec9f594d04a08ee876c83759e2314ec8b1a"
+				},
 				"version": 5
 			}
-		},
-		"spec_version": "1.0",
-		"version": 5
-	}
+		}
+	},
+	"signatures": [
+		{
+			"keyid": "b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef",
+			"sig": "c9da15fd5b0b359a46503d0a23fa3a4e8e481cb2bdb72d6dbec4852ed6f9d32e186b35071b6ca70ec947e1688458c3476d33991af202b177ffd79ff89955e703"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-true/4/repository/5.targets.json
+++ b/client/testdata/go-tuf/consistent-snapshot-true/4/repository/5.targets.json
@@ -1,46 +1,46 @@
 {
+	"signed": {
+		"_type": "targets",
+		"spec_version": "1.0",
+		"version": 5,
+		"expires": "2100-01-01T00:00:00Z",
+		"targets": {
+			"0": {
+				"length": 1,
+				"hashes": {
+					"sha512": "31bca02094eb78126a517b206a88c73cfa9ec6f704c7030d18212cace820f025f00bf0ea68dbf3f3a5436ca63b53bf7bf80ad8d5de7d8359d0b7fed9dbc3ab99"
+				}
+			},
+			"1": {
+				"length": 1,
+				"hashes": {
+					"sha512": "4dff4ea340f0a823f15d3f4f01ab62eae0e5da579ccb851f8db9dfe84c58b2b37b89903a740e1ee172da793a6e79d560e5f7f9bd058a12a280433ed6fa46510a"
+				}
+			},
+			"2": {
+				"length": 1,
+				"hashes": {
+					"sha512": "40b244112641dd78dd4f93b6c9190dd46e0099194d5a44257b7efad6ef9ff4683da1eda0244448cb343aa688f5d3efd7314dafe580ac0bcbf115aeca9e8dc114"
+				}
+			},
+			"3": {
+				"length": 1,
+				"hashes": {
+					"sha512": "3bafbf08882a2d10133093a1b8433f50563b93c14acd05b79028eb1d12799027241450980651994501423a66c276ae26c43b739bc65c4e16b10c3af6c202aebb"
+				}
+			},
+			"4": {
+				"length": 1,
+				"hashes": {
+					"sha512": "a321d8b405e3ef2604959847b36d171eebebc4a8941dc70a4784935a4fca5d5813de84dfa049f06549aa61b20848c1633ce81b675286ea8fb53db240d831c568"
+				}
+			}
+		}
+	},
 	"signatures": [
 		{
 			"keyid": "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1",
 			"sig": "68f2346cdbe045e8558b2ccd86be66e15466955167557c704b51d7163838f670c53ab9247c16a4ed0cd4ecc981a7e2a04a350b01548f97654499d6f9c17c4202"
 		}
-	],
-	"signed": {
-		"_type": "targets",
-		"expires": "2100-01-01T00:00:00Z",
-		"spec_version": "1.0",
-		"targets": {
-			"0": {
-				"hashes": {
-					"sha512": "31bca02094eb78126a517b206a88c73cfa9ec6f704c7030d18212cace820f025f00bf0ea68dbf3f3a5436ca63b53bf7bf80ad8d5de7d8359d0b7fed9dbc3ab99"
-				},
-				"length": 1
-			},
-			"1": {
-				"hashes": {
-					"sha512": "4dff4ea340f0a823f15d3f4f01ab62eae0e5da579ccb851f8db9dfe84c58b2b37b89903a740e1ee172da793a6e79d560e5f7f9bd058a12a280433ed6fa46510a"
-				},
-				"length": 1
-			},
-			"2": {
-				"hashes": {
-					"sha512": "40b244112641dd78dd4f93b6c9190dd46e0099194d5a44257b7efad6ef9ff4683da1eda0244448cb343aa688f5d3efd7314dafe580ac0bcbf115aeca9e8dc114"
-				},
-				"length": 1
-			},
-			"3": {
-				"hashes": {
-					"sha512": "3bafbf08882a2d10133093a1b8433f50563b93c14acd05b79028eb1d12799027241450980651994501423a66c276ae26c43b739bc65c4e16b10c3af6c202aebb"
-				},
-				"length": 1
-			},
-			"4": {
-				"hashes": {
-					"sha512": "a321d8b405e3ef2604959847b36d171eebebc4a8941dc70a4784935a4fca5d5813de84dfa049f06549aa61b20848c1633ce81b675286ea8fb53db240d831c568"
-				},
-				"length": 1
-			}
-		},
-		"version": 5
-	}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-true/4/repository/root.json
+++ b/client/testdata/go-tuf/consistent-snapshot-true/4/repository/root.json
@@ -1,58 +1,53 @@
 {
-	"signatures": [
-		{
-			"keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
-			"sig": "2b6f30258eaf8b4b2d900a2efb4a597b45a9c0c5a0720d5521dd37d63c34d1db62aafaa1d95b6d881f9c991615ab68930c24ef247d2f45836bca3659e36d9c0b"
-		}
-	],
 	"signed": {
 		"_type": "root",
-		"consistent_snapshot": true,
+		"spec_version": "1.0",
+		"version": 5,
 		"expires": "2100-01-01T00:00:00Z",
 		"keys": {
 			"a8eaf6de5aecfd0a72b60295b1e1cd12f349079ebcbbb63dbe7072f162e85315": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "3ab34b0c2d4eadccaa0f0cf22ced07b552394063a9de2806993d022360dffc76"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "722dbc861813bb5b568524d62083e875c08e66fed1694d9161d253fa163dd86f"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "153986a7370e002f377dd68797e7466c421180c1571e233de2f8ab41c8af4f54"
-				},
-				"scheme": "ed25519"
+				}
 			},
 			"bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1": {
+				"keytype": "ed25519",
+				"scheme": "ed25519",
 				"keyid_hash_algorithms": [
 					"sha256",
 					"sha512"
 				],
-				"keytype": "ed25519",
 				"keyval": {
 					"public": "aee574e56780ea1709a8b56e02d4ffdd9a3a1deaed61e2eb0701f376a4422e42"
-				},
-				"scheme": "ed25519"
+				}
 			}
 		},
 		"roles": {
@@ -81,7 +76,12 @@
 				"threshold": 1
 			}
 		},
-		"spec_version": "1.0",
-		"version": 5
-	}
+		"consistent_snapshot": true
+	},
+	"signatures": [
+		{
+			"keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
+			"sig": "2b6f30258eaf8b4b2d900a2efb4a597b45a9c0c5a0720d5521dd37d63c34d1db62aafaa1d95b6d881f9c991615ab68930c24ef247d2f45836bca3659e36d9c0b"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-true/4/repository/snapshot.json
+++ b/client/testdata/go-tuf/consistent-snapshot-true/4/repository/snapshot.json
@@ -1,23 +1,23 @@
 {
-	"signatures": [
-		{
-			"keyid": "b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef",
-			"sig": "8ce62f94026a58e31a875017e0d10806e19e9541469330cdbfcd9ebfa5f0c317c7eb203256d114307d018400521add578bd2a11c85b5328af3e4efd471b92307"
-		}
-	],
 	"signed": {
 		"_type": "snapshot",
+		"spec_version": "1.0",
+		"version": 5,
 		"expires": "2100-01-01T00:00:00Z",
 		"meta": {
 			"targets.json": {
-				"hashes": {
-					"sha512": "6832a32afe35bb07557081f3a935296cde39c39f6bca65bd068c337743b570818ff6c04a968a40b83228b46d214b44528719babfa3314658df36d4b21b0757ae"
-				},
 				"length": 1392,
+				"hashes": {
+					"sha512": "93146957ab1f54fe1e8687f408c21a19ad6c033518148bb730b7e635e02f96d9297f1edf12ea5f50354cfcb90385eec9f594d04a08ee876c83759e2314ec8b1a"
+				},
 				"version": 5
 			}
-		},
-		"spec_version": "1.0",
-		"version": 5
-	}
+		}
+	},
+	"signatures": [
+		{
+			"keyid": "b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef",
+			"sig": "c9da15fd5b0b359a46503d0a23fa3a4e8e481cb2bdb72d6dbec4852ed6f9d32e186b35071b6ca70ec947e1688458c3476d33991af202b177ffd79ff89955e703"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-true/4/repository/targets.json
+++ b/client/testdata/go-tuf/consistent-snapshot-true/4/repository/targets.json
@@ -1,46 +1,46 @@
 {
+	"signed": {
+		"_type": "targets",
+		"spec_version": "1.0",
+		"version": 5,
+		"expires": "2100-01-01T00:00:00Z",
+		"targets": {
+			"0": {
+				"length": 1,
+				"hashes": {
+					"sha512": "31bca02094eb78126a517b206a88c73cfa9ec6f704c7030d18212cace820f025f00bf0ea68dbf3f3a5436ca63b53bf7bf80ad8d5de7d8359d0b7fed9dbc3ab99"
+				}
+			},
+			"1": {
+				"length": 1,
+				"hashes": {
+					"sha512": "4dff4ea340f0a823f15d3f4f01ab62eae0e5da579ccb851f8db9dfe84c58b2b37b89903a740e1ee172da793a6e79d560e5f7f9bd058a12a280433ed6fa46510a"
+				}
+			},
+			"2": {
+				"length": 1,
+				"hashes": {
+					"sha512": "40b244112641dd78dd4f93b6c9190dd46e0099194d5a44257b7efad6ef9ff4683da1eda0244448cb343aa688f5d3efd7314dafe580ac0bcbf115aeca9e8dc114"
+				}
+			},
+			"3": {
+				"length": 1,
+				"hashes": {
+					"sha512": "3bafbf08882a2d10133093a1b8433f50563b93c14acd05b79028eb1d12799027241450980651994501423a66c276ae26c43b739bc65c4e16b10c3af6c202aebb"
+				}
+			},
+			"4": {
+				"length": 1,
+				"hashes": {
+					"sha512": "a321d8b405e3ef2604959847b36d171eebebc4a8941dc70a4784935a4fca5d5813de84dfa049f06549aa61b20848c1633ce81b675286ea8fb53db240d831c568"
+				}
+			}
+		}
+	},
 	"signatures": [
 		{
 			"keyid": "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1",
 			"sig": "68f2346cdbe045e8558b2ccd86be66e15466955167557c704b51d7163838f670c53ab9247c16a4ed0cd4ecc981a7e2a04a350b01548f97654499d6f9c17c4202"
 		}
-	],
-	"signed": {
-		"_type": "targets",
-		"expires": "2100-01-01T00:00:00Z",
-		"spec_version": "1.0",
-		"targets": {
-			"0": {
-				"hashes": {
-					"sha512": "31bca02094eb78126a517b206a88c73cfa9ec6f704c7030d18212cace820f025f00bf0ea68dbf3f3a5436ca63b53bf7bf80ad8d5de7d8359d0b7fed9dbc3ab99"
-				},
-				"length": 1
-			},
-			"1": {
-				"hashes": {
-					"sha512": "4dff4ea340f0a823f15d3f4f01ab62eae0e5da579ccb851f8db9dfe84c58b2b37b89903a740e1ee172da793a6e79d560e5f7f9bd058a12a280433ed6fa46510a"
-				},
-				"length": 1
-			},
-			"2": {
-				"hashes": {
-					"sha512": "40b244112641dd78dd4f93b6c9190dd46e0099194d5a44257b7efad6ef9ff4683da1eda0244448cb343aa688f5d3efd7314dafe580ac0bcbf115aeca9e8dc114"
-				},
-				"length": 1
-			},
-			"3": {
-				"hashes": {
-					"sha512": "3bafbf08882a2d10133093a1b8433f50563b93c14acd05b79028eb1d12799027241450980651994501423a66c276ae26c43b739bc65c4e16b10c3af6c202aebb"
-				},
-				"length": 1
-			},
-			"4": {
-				"hashes": {
-					"sha512": "a321d8b405e3ef2604959847b36d171eebebc4a8941dc70a4784935a4fca5d5813de84dfa049f06549aa61b20848c1633ce81b675286ea8fb53db240d831c568"
-				},
-				"length": 1
-			}
-		},
-		"version": 5
-	}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-true/4/repository/timestamp.json
+++ b/client/testdata/go-tuf/consistent-snapshot-true/4/repository/timestamp.json
@@ -1,23 +1,23 @@
 {
-	"signatures": [
-		{
-			"keyid": "a8eaf6de5aecfd0a72b60295b1e1cd12f349079ebcbbb63dbe7072f162e85315",
-			"sig": "36fcb1d9c0e69fe2cd472d97835077b30340da0a326d8d20e844f6a1a84fba439c1662150e029032756b98cd9062686216a77a52b78c6641cd57e8f597d1380b"
-		}
-	],
 	"signed": {
 		"_type": "timestamp",
+		"spec_version": "1.0",
+		"version": 5,
 		"expires": "2100-01-01T00:00:00Z",
 		"meta": {
 			"snapshot.json": {
-				"hashes": {
-					"sha512": "1a984612b0f1657b0a6974bf91e9b33c71a84709a6b36aa76dda4aaea1d132fdd3ef5fd777433a31908bec1f1a39984f9dcc72c3ddbf6b8ed92a7c779d080702"
-				},
 				"length": 618,
+				"hashes": {
+					"sha512": "066115510f2f7fbb2f5cb0a1c1d00759161d8a92329e9ce54d4b17c06466b5a4423bb8bcc9e47c0a37db5c7d8d3bc01df10c4ea25605778e788a76e3e9ca1e0e"
+				},
 				"version": 5
 			}
-		},
-		"spec_version": "1.0",
-		"version": 5
-	}
+		}
+	},
+	"signatures": [
+		{
+			"keyid": "a8eaf6de5aecfd0a72b60295b1e1cd12f349079ebcbbb63dbe7072f162e85315",
+			"sig": "84b9e41c93b32eed4bdb6febe70f9bd4db39bbc7f0c7f820f6a078bbb7146df080a9ceaa237303e3f69e49eb33cc63f8ddff8fba8330904f5fe8d7a66f70400e"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-true/5/repository/6.snapshot.json
+++ b/client/testdata/go-tuf/consistent-snapshot-true/5/repository/6.snapshot.json
@@ -1,23 +1,23 @@
 {
-	"signatures": [
-		{
-			"keyid": "b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef",
-			"sig": "7ed4b5c650c534154241ee575862730940ecdc61daa4dbbae167aefa2fe2ab47a6dcbccd099ab15630c6ebfd6acdfbacd89f30a6186c791b58a8dc0769bea405"
-		}
-	],
 	"signed": {
 		"_type": "snapshot",
+		"spec_version": "1.0",
+		"version": 6,
 		"expires": "2100-01-01T00:00:00Z",
 		"meta": {
 			"targets.json": {
-				"hashes": {
-					"sha512": "97c2b46ccae4c2338d99819425239796c6647bf242ac64f13ec9347ec38fd8c6a5470756c079e1aaa23a013a8a720440f3128bd6c99f3c9f32492dd829726eee"
-				},
 				"length": 1593,
+				"hashes": {
+					"sha512": "96fa32225e88f9e98db51369fce606039040efc51f098552594132b301228a78c2f2034d059e4d7d6d7bea14ae9862dd8a995056c5f2ed5ff0d6dc09b9da01df"
+				},
 				"version": 6
 			}
-		},
-		"spec_version": "1.0",
-		"version": 6
-	}
+		}
+	},
+	"signatures": [
+		{
+			"keyid": "b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef",
+			"sig": "7da0cd1e09be0b8161a1048e08a645e5c8d1558137b2934418bf4e28d4d380b6df2306f5cc89e87e41e5abf079547a709fccd2548bf00fd5acfe5ad2496d670b"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-true/5/repository/6.targets.json
+++ b/client/testdata/go-tuf/consistent-snapshot-true/5/repository/6.targets.json
@@ -1,52 +1,52 @@
 {
+	"signed": {
+		"_type": "targets",
+		"spec_version": "1.0",
+		"version": 6,
+		"expires": "2100-01-01T00:00:00Z",
+		"targets": {
+			"0": {
+				"length": 1,
+				"hashes": {
+					"sha512": "31bca02094eb78126a517b206a88c73cfa9ec6f704c7030d18212cace820f025f00bf0ea68dbf3f3a5436ca63b53bf7bf80ad8d5de7d8359d0b7fed9dbc3ab99"
+				}
+			},
+			"1": {
+				"length": 1,
+				"hashes": {
+					"sha512": "4dff4ea340f0a823f15d3f4f01ab62eae0e5da579ccb851f8db9dfe84c58b2b37b89903a740e1ee172da793a6e79d560e5f7f9bd058a12a280433ed6fa46510a"
+				}
+			},
+			"2": {
+				"length": 1,
+				"hashes": {
+					"sha512": "40b244112641dd78dd4f93b6c9190dd46e0099194d5a44257b7efad6ef9ff4683da1eda0244448cb343aa688f5d3efd7314dafe580ac0bcbf115aeca9e8dc114"
+				}
+			},
+			"3": {
+				"length": 1,
+				"hashes": {
+					"sha512": "3bafbf08882a2d10133093a1b8433f50563b93c14acd05b79028eb1d12799027241450980651994501423a66c276ae26c43b739bc65c4e16b10c3af6c202aebb"
+				}
+			},
+			"4": {
+				"length": 1,
+				"hashes": {
+					"sha512": "a321d8b405e3ef2604959847b36d171eebebc4a8941dc70a4784935a4fca5d5813de84dfa049f06549aa61b20848c1633ce81b675286ea8fb53db240d831c568"
+				}
+			},
+			"5": {
+				"length": 1,
+				"hashes": {
+					"sha512": "06df05371981a237d0ed11472fae7c94c9ac0eff1d05413516710d17b10a4fb6f4517bda4a695f02d0a73dd4db543b4653df28f5d09dab86f92ffb9b86d01e25"
+				}
+			}
+		}
+	},
 	"signatures": [
 		{
 			"keyid": "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1",
 			"sig": "1e80ae84c4badf194e2fd7225c120999d8f628598fa0e994a2ff7cac705ec2f14601a64ba5370fc668f3fb114975dd81c554400d757f41762c4e12eb4db35d02"
 		}
-	],
-	"signed": {
-		"_type": "targets",
-		"expires": "2100-01-01T00:00:00Z",
-		"spec_version": "1.0",
-		"targets": {
-			"0": {
-				"hashes": {
-					"sha512": "31bca02094eb78126a517b206a88c73cfa9ec6f704c7030d18212cace820f025f00bf0ea68dbf3f3a5436ca63b53bf7bf80ad8d5de7d8359d0b7fed9dbc3ab99"
-				},
-				"length": 1
-			},
-			"1": {
-				"hashes": {
-					"sha512": "4dff4ea340f0a823f15d3f4f01ab62eae0e5da579ccb851f8db9dfe84c58b2b37b89903a740e1ee172da793a6e79d560e5f7f9bd058a12a280433ed6fa46510a"
-				},
-				"length": 1
-			},
-			"2": {
-				"hashes": {
-					"sha512": "40b244112641dd78dd4f93b6c9190dd46e0099194d5a44257b7efad6ef9ff4683da1eda0244448cb343aa688f5d3efd7314dafe580ac0bcbf115aeca9e8dc114"
-				},
-				"length": 1
-			},
-			"3": {
-				"hashes": {
-					"sha512": "3bafbf08882a2d10133093a1b8433f50563b93c14acd05b79028eb1d12799027241450980651994501423a66c276ae26c43b739bc65c4e16b10c3af6c202aebb"
-				},
-				"length": 1
-			},
-			"4": {
-				"hashes": {
-					"sha512": "a321d8b405e3ef2604959847b36d171eebebc4a8941dc70a4784935a4fca5d5813de84dfa049f06549aa61b20848c1633ce81b675286ea8fb53db240d831c568"
-				},
-				"length": 1
-			},
-			"5": {
-				"hashes": {
-					"sha512": "06df05371981a237d0ed11472fae7c94c9ac0eff1d05413516710d17b10a4fb6f4517bda4a695f02d0a73dd4db543b4653df28f5d09dab86f92ffb9b86d01e25"
-				},
-				"length": 1
-			}
-		},
-		"version": 6
-	}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-true/5/repository/snapshot.json
+++ b/client/testdata/go-tuf/consistent-snapshot-true/5/repository/snapshot.json
@@ -1,23 +1,23 @@
 {
-	"signatures": [
-		{
-			"keyid": "b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef",
-			"sig": "7ed4b5c650c534154241ee575862730940ecdc61daa4dbbae167aefa2fe2ab47a6dcbccd099ab15630c6ebfd6acdfbacd89f30a6186c791b58a8dc0769bea405"
-		}
-	],
 	"signed": {
 		"_type": "snapshot",
+		"spec_version": "1.0",
+		"version": 6,
 		"expires": "2100-01-01T00:00:00Z",
 		"meta": {
 			"targets.json": {
-				"hashes": {
-					"sha512": "97c2b46ccae4c2338d99819425239796c6647bf242ac64f13ec9347ec38fd8c6a5470756c079e1aaa23a013a8a720440f3128bd6c99f3c9f32492dd829726eee"
-				},
 				"length": 1593,
+				"hashes": {
+					"sha512": "96fa32225e88f9e98db51369fce606039040efc51f098552594132b301228a78c2f2034d059e4d7d6d7bea14ae9862dd8a995056c5f2ed5ff0d6dc09b9da01df"
+				},
 				"version": 6
 			}
-		},
-		"spec_version": "1.0",
-		"version": 6
-	}
+		}
+	},
+	"signatures": [
+		{
+			"keyid": "b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef",
+			"sig": "7da0cd1e09be0b8161a1048e08a645e5c8d1558137b2934418bf4e28d4d380b6df2306f5cc89e87e41e5abf079547a709fccd2548bf00fd5acfe5ad2496d670b"
+		}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-true/5/repository/targets.json
+++ b/client/testdata/go-tuf/consistent-snapshot-true/5/repository/targets.json
@@ -1,52 +1,52 @@
 {
+	"signed": {
+		"_type": "targets",
+		"spec_version": "1.0",
+		"version": 6,
+		"expires": "2100-01-01T00:00:00Z",
+		"targets": {
+			"0": {
+				"length": 1,
+				"hashes": {
+					"sha512": "31bca02094eb78126a517b206a88c73cfa9ec6f704c7030d18212cace820f025f00bf0ea68dbf3f3a5436ca63b53bf7bf80ad8d5de7d8359d0b7fed9dbc3ab99"
+				}
+			},
+			"1": {
+				"length": 1,
+				"hashes": {
+					"sha512": "4dff4ea340f0a823f15d3f4f01ab62eae0e5da579ccb851f8db9dfe84c58b2b37b89903a740e1ee172da793a6e79d560e5f7f9bd058a12a280433ed6fa46510a"
+				}
+			},
+			"2": {
+				"length": 1,
+				"hashes": {
+					"sha512": "40b244112641dd78dd4f93b6c9190dd46e0099194d5a44257b7efad6ef9ff4683da1eda0244448cb343aa688f5d3efd7314dafe580ac0bcbf115aeca9e8dc114"
+				}
+			},
+			"3": {
+				"length": 1,
+				"hashes": {
+					"sha512": "3bafbf08882a2d10133093a1b8433f50563b93c14acd05b79028eb1d12799027241450980651994501423a66c276ae26c43b739bc65c4e16b10c3af6c202aebb"
+				}
+			},
+			"4": {
+				"length": 1,
+				"hashes": {
+					"sha512": "a321d8b405e3ef2604959847b36d171eebebc4a8941dc70a4784935a4fca5d5813de84dfa049f06549aa61b20848c1633ce81b675286ea8fb53db240d831c568"
+				}
+			},
+			"5": {
+				"length": 1,
+				"hashes": {
+					"sha512": "06df05371981a237d0ed11472fae7c94c9ac0eff1d05413516710d17b10a4fb6f4517bda4a695f02d0a73dd4db543b4653df28f5d09dab86f92ffb9b86d01e25"
+				}
+			}
+		}
+	},
 	"signatures": [
 		{
 			"keyid": "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1",
 			"sig": "1e80ae84c4badf194e2fd7225c120999d8f628598fa0e994a2ff7cac705ec2f14601a64ba5370fc668f3fb114975dd81c554400d757f41762c4e12eb4db35d02"
 		}
-	],
-	"signed": {
-		"_type": "targets",
-		"expires": "2100-01-01T00:00:00Z",
-		"spec_version": "1.0",
-		"targets": {
-			"0": {
-				"hashes": {
-					"sha512": "31bca02094eb78126a517b206a88c73cfa9ec6f704c7030d18212cace820f025f00bf0ea68dbf3f3a5436ca63b53bf7bf80ad8d5de7d8359d0b7fed9dbc3ab99"
-				},
-				"length": 1
-			},
-			"1": {
-				"hashes": {
-					"sha512": "4dff4ea340f0a823f15d3f4f01ab62eae0e5da579ccb851f8db9dfe84c58b2b37b89903a740e1ee172da793a6e79d560e5f7f9bd058a12a280433ed6fa46510a"
-				},
-				"length": 1
-			},
-			"2": {
-				"hashes": {
-					"sha512": "40b244112641dd78dd4f93b6c9190dd46e0099194d5a44257b7efad6ef9ff4683da1eda0244448cb343aa688f5d3efd7314dafe580ac0bcbf115aeca9e8dc114"
-				},
-				"length": 1
-			},
-			"3": {
-				"hashes": {
-					"sha512": "3bafbf08882a2d10133093a1b8433f50563b93c14acd05b79028eb1d12799027241450980651994501423a66c276ae26c43b739bc65c4e16b10c3af6c202aebb"
-				},
-				"length": 1
-			},
-			"4": {
-				"hashes": {
-					"sha512": "a321d8b405e3ef2604959847b36d171eebebc4a8941dc70a4784935a4fca5d5813de84dfa049f06549aa61b20848c1633ce81b675286ea8fb53db240d831c568"
-				},
-				"length": 1
-			},
-			"5": {
-				"hashes": {
-					"sha512": "06df05371981a237d0ed11472fae7c94c9ac0eff1d05413516710d17b10a4fb6f4517bda4a695f02d0a73dd4db543b4653df28f5d09dab86f92ffb9b86d01e25"
-				},
-				"length": 1
-			}
-		},
-		"version": 6
-	}
+	]
 }

--- a/client/testdata/go-tuf/consistent-snapshot-true/5/repository/timestamp.json
+++ b/client/testdata/go-tuf/consistent-snapshot-true/5/repository/timestamp.json
@@ -1,23 +1,23 @@
 {
-	"signatures": [
-		{
-			"keyid": "a8eaf6de5aecfd0a72b60295b1e1cd12f349079ebcbbb63dbe7072f162e85315",
-			"sig": "b90b0eaa68d6fbd0fda91dc5c9c27b5ad33665c4cb92e9dfa06742ba71870cb7fcc72d373970f35525c60523a16bae9720d6964da84f579f50480d7f6b27dc01"
-		}
-	],
 	"signed": {
 		"_type": "timestamp",
+		"spec_version": "1.0",
+		"version": 6,
 		"expires": "2100-01-01T00:00:00Z",
 		"meta": {
 			"snapshot.json": {
-				"hashes": {
-					"sha512": "69fe654899c63eedc38d481b56030c560967d00a5e709d536b89de7d166945bce2d5c91737a7b54eb058fccb11c2f8ea300c2529c94263a1f6bcadddfb709cc7"
-				},
 				"length": 618,
+				"hashes": {
+					"sha512": "7113ee370f6e1b35df7fd8203d27760e8eb8c32195e8a895f140584caff81256ccdf2d03ed43a5efac45ee4f869908cee2275c0f7e6b54969602e0542c9f78f9"
+				},
 				"version": 6
 			}
-		},
-		"spec_version": "1.0",
-		"version": 6
-	}
+		}
+	},
+	"signatures": [
+		{
+			"keyid": "a8eaf6de5aecfd0a72b60295b1e1cd12f349079ebcbbb63dbe7072f162e85315",
+			"sig": "85758e7d1cdbedfd3d363136924a6e7878a2b9b68486ecc65658a29f96b55fcfeeda0f94fcae30fa3ceafc3ef5f82df8c68ad2774b6e4f4ea0e6cdbafdce8e0f"
+		}
+	]
 }

--- a/repo.go
+++ b/repo.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/secure-systems-lab/go-securesystemslib/cjson"
 	"github.com/theupdateframework/go-tuf/data"
 	"github.com/theupdateframework/go-tuf/internal/roles"
 	"github.com/theupdateframework/go-tuf/internal/signer"
@@ -485,21 +484,10 @@ func (r *Repo) RevokeKeyWithExpires(keyRole, id string, expires time.Time) error
 }
 
 func (r *Repo) jsonMarshal(v interface{}) ([]byte, error) {
-	b, err := cjson.EncodeCanonical(v)
-	if err != nil {
-		return []byte{}, err
-	}
-
 	if r.prefix == "" && r.indent == "" {
-		return b, nil
+		return json.Marshal(v)
 	}
-
-	var out bytes.Buffer
-	if err := json.Indent(&out, b, r.prefix, r.indent); err != nil {
-		return []byte{}, err
-	}
-
-	return out.Bytes(), nil
+	return json.MarshalIndent(v, r.prefix, r.indent)
 }
 
 func (r *Repo) setTopLevelMeta(roleFilename string, meta interface{}) error {

--- a/repo_test.go
+++ b/repo_test.go
@@ -1692,7 +1692,9 @@ func (rs *RepoSuite) TestAddOrUpdateSignatures(c *C) {
 	// generate signatures externally and append
 	rootMeta, err := r.SignedMeta("root.json")
 	c.Assert(err, IsNil)
-	rootSig, err := rootKey.SignMessage(rootMeta.Signed)
+	rootCanonical, err := cjson.EncodeCanonical(rootMeta.Signed)
+	c.Assert(err, IsNil)
+	rootSig, err := rootKey.SignMessage(rootCanonical)
 	c.Assert(err, IsNil)
 	for _, id := range rootKey.PublicData().IDs() {
 		c.Assert(r.AddOrUpdateSignature("root.json", data.Signature{
@@ -1704,7 +1706,9 @@ func (rs *RepoSuite) TestAddOrUpdateSignatures(c *C) {
 	c.Assert(r.AddTarget("foo.txt", nil), IsNil)
 	targetsMeta, err := r.SignedMeta("targets.json")
 	c.Assert(err, IsNil)
-	targetsSig, err := targetsKey.SignMessage(targetsMeta.Signed)
+	targetsCanonical, err := cjson.EncodeCanonical(targetsMeta.Signed)
+	c.Assert(err, IsNil)
+	targetsSig, err := targetsKey.SignMessage(targetsCanonical)
 	c.Assert(err, IsNil)
 	for _, id := range targetsKey.PublicData().IDs() {
 		r.AddOrUpdateSignature("targets.json", data.Signature{
@@ -1716,7 +1720,9 @@ func (rs *RepoSuite) TestAddOrUpdateSignatures(c *C) {
 	c.Assert(r.Snapshot(), IsNil)
 	snapshotMeta, err := r.SignedMeta("snapshot.json")
 	c.Assert(err, IsNil)
-	snapshotSig, err := snapshotKey.SignMessage(snapshotMeta.Signed)
+	snapshotCanonical, err := cjson.EncodeCanonical(snapshotMeta.Signed)
+	c.Assert(err, IsNil)
+	snapshotSig, err := snapshotKey.SignMessage(snapshotCanonical)
 	c.Assert(err, IsNil)
 	for _, id := range snapshotKey.PublicData().IDs() {
 		r.AddOrUpdateSignature("snapshot.json", data.Signature{
@@ -1727,7 +1733,9 @@ func (rs *RepoSuite) TestAddOrUpdateSignatures(c *C) {
 	c.Assert(r.Timestamp(), IsNil)
 	timestampMeta, err := r.SignedMeta("timestamp.json")
 	c.Assert(err, IsNil)
-	timestampSig, err := timestampKey.SignMessage(timestampMeta.Signed)
+	timestampCanonical, err := cjson.EncodeCanonical(timestampMeta.Signed)
+	c.Assert(err, IsNil)
+	timestampSig, err := timestampKey.SignMessage(timestampCanonical)
 	c.Assert(err, IsNil)
 	for _, id := range timestampKey.PublicData().IDs() {
 		r.AddOrUpdateSignature("timestamp.json", data.Signature{
@@ -1769,7 +1777,9 @@ func (rs *RepoSuite) TestBadAddOrUpdateSignatures(c *C) {
 	// add a signature with a bad role
 	rootMeta, err := r.SignedMeta("root.json")
 	c.Assert(err, IsNil)
-	rootSig, err := rootKey.Sign(rand.Reader, rootMeta.Signed, crypto.Hash(0))
+	rootCanonical, err := cjson.EncodeCanonical(rootMeta.Signed)
+	c.Assert(err, IsNil)
+	rootSig, err := rootKey.Sign(rand.Reader, rootCanonical, crypto.Hash(0))
 	c.Assert(err, IsNil)
 	for _, id := range rootKey.PublicData().IDs() {
 		c.Assert(r.AddOrUpdateSignature("invalid_root.json", data.Signature{

--- a/sign/sign.go
+++ b/sign/sign.go
@@ -1,6 +1,8 @@
 package sign
 
 import (
+	"encoding/json"
+
 	"github.com/secure-systems-lab/go-securesystemslib/cjson"
 	"github.com/theupdateframework/go-tuf/data"
 	"github.com/theupdateframework/go-tuf/pkg/keys"
@@ -22,7 +24,12 @@ func Sign(s *data.Signed, k keys.Signer) error {
 		}
 	}
 
-	sig, err := k.SignMessage(s.Signed)
+	canonical, err := cjson.EncodeCanonical(s.Signed)
+	if err != nil {
+		return err
+	}
+
+	sig, err := k.SignMessage(canonical)
 	if err != nil {
 		return err
 	}
@@ -39,7 +46,7 @@ func Sign(s *data.Signed, k keys.Signer) error {
 }
 
 func Marshal(v interface{}, keys ...keys.Signer) (*data.Signed, error) {
-	b, err := cjson.EncodeCanonical(v)
+	b, err := json.Marshal(v)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #246

Release Notes:
- Fixes error in JSON canonicalisation that stops RSA/ECDSA keys from being marshalled correctly.

**Types of changes**:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

I don't believe this breaks any compatibility, a valid client should still canonicalise the message before hashing.

**Description of the changes being introduced by the pull request**:

The JSON canonicalisation format (specified here: https://wiki.laptop.org/go/Canonical_JSON) does not escape of control sequences in string values, however the JSON standard (https://www.ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf) requires that all control characters (defined as U+0000 to U+001F) MUST be escaped in strings.

As a result new line characters in strings are not escaped and this produces invalid JSON and go-tuf will fail to marshal metadata containing these sequences. This is particularly problematic for RSA and ECDSA keys where the specification states they are encoded in PEM format, which will inevitably contain newline characters.

This change only changes repo to only used canonicalised JSON format for calculating the signature of the message. The serialised message just uses the standard library encoding/json, which correctly handles all control sequences to produce a valid JSON encoding.

The changes to tests are required as they use the `github.com/theupdateframework/go-tuf/pkg/keys.Signer.SignMessage` method directly, this method accepts a `[]byte` instead of a `json.RawMessage`, which implies that it expects a canonicalised message and will not perform canonicalisation.

**Please verify and check that the pull request fulfills the following requirements**:

- [x] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature
