### PR TITLE
add import-key cli command to import an existing key

### DIFF
--- a/cmd/tuf/import_key.go
+++ b/cmd/tuf/import_key.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/flynn/go-docopt"
+	"github.com/theupdateframework/go-tuf"
+	"github.com/theupdateframework/go-tuf/data"
+	"github.com/theupdateframework/go-tuf/pkg/keys"
+)
+
+func init() {
+	register("import-key", cmdImportKey, `
+usage: tuf import-key [--expires=<days>] <role> <file>
+
+Import an existing signing key for the given role.
+
+The key will be imported from the file and added to the "keys" directory with
+filename pattern "ROLE-KEYID.json". The root metadata file will also be staged
+with the addition of the key's ID to the role's list of key IDs.
+
+Options:
+  --expires=<days>   Set the root metadata file to expire <days> days from now.
+`)
+}
+
+func cmdImportKey(args *docopt.Args, repo *tuf.Repo) error {
+	role := args.String["<role>"]
+	file := args.String["<file>"]
+	var err error
+
+	var privateKey data.PrivateKey
+	data, err := os.ReadFile(file)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(data, &privateKey); err != nil {
+		return fmt.Errorf("failed to unmarshal key file: %w", err)
+	}
+
+	signer, err := keys.GetSigner(&privateKey)
+	if err != nil {
+		return fmt.Errorf("failed to get signer for key file: %w", err)
+	}
+
+	if arg := args.String["--expires"]; arg != "" {
+		var expires time.Time
+		expires, err = parseExpires(arg)
+		if err != nil {
+			return err
+		}
+		err = repo.AddPrivateKeyWithExpires(role, signer, expires)
+	} else {
+		err = repo.AddPrivateKey(role, signer)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to add key to repository: %w", err)
+	}
+
+	keyids := signer.PublicData().IDs()
+	for _, id := range keyids {
+		fmt.Println("Imported", role, "key with ID", id)
+	}
+	return nil
+}

--- a/cmd/tuf/import_key.go
+++ b/cmd/tuf/import_key.go
@@ -14,15 +14,16 @@ import (
 
 func init() {
 	register("import-key", cmdImportKey, `
-usage: tuf import-key [--expires=<days>] <role> <file>
+usage: tuf import-key [--expires=<days>] --role=<role> <file>
 
 Import an existing signing key for the given role.
 
-The key will be imported from the file and added to the "keys" directory with
-filename pattern "ROLE-KEYID.json". The root metadata file will also be staged
-with the addition of the key's ID to the role's list of key IDs.
+The private key will be read from the file and added key store.
+The root metadata file will also be staged with the addition of the key's ID to
+the role's list of key IDs.
 
 Options:
+  --role=<role>      The role to import the key for (required).
   --expires=<days>   Set the root metadata file to expire <days> days from now.
 `)
 }
@@ -31,6 +32,10 @@ func cmdImportKey(args *docopt.Args, repo *tuf.Repo) error {
 	role := args.String["<role>"]
 	file := args.String["<file>"]
 	var err error
+
+	if role == "" {
+		return fmt.Errorf("role is required")
+	}
 
 	var privateKey data.PrivateKey
 	data, err := os.ReadFile(file)

--- a/cmd/tuf/main.go
+++ b/cmd/tuf/main.go
@@ -31,6 +31,7 @@ Commands:
   help               Show usage for a specific command
   init               Initialize a new repository
   gen-key            Generate a new signing key for a specific metadata file
+  import-key         Import an existing key into repository
   revoke-key         Revoke a signing key
   add                Add target file(s)
   remove             Remove a target file


### PR DESCRIPTION
Release Notes:
- Added `import-key` sub-command to the tuf cli to import an existing private key into the local key store and add an entry in the root metadata.

**Types of changes**:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Description of the changes being introduced by the pull request**:

Adds an import-key sub-command to import an existing private key into the local key store and add a corresponding entry in the root metadata.

The reason for this change is that I'm separately working on adding support for storing keys in cloud KMS and Yubikeys. In these cases the key is generated externally and through separate tooling it can then generate a `data.PrivateKey` (in these cases the key type will be some custom type, and the key value will be the path to the key in KMS/Yubikey Serial+Slot), and so this command is necessary to be able to add these keys.

**Please verify and check that the pull request fulfills the following requirements**:

- [ ] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature
