### PR TITLE
chore: remove exposing the github oidc token in ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,6 @@ name: Release
 jobs:
   release:
     permissions:
-      id-token: write
       contents: write
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Exposing the OIDC token is not necessary until we decide to use an OIDC issuer for signing.

Signed-off-by: Radoslav Dimitrov <dimitrovr@vmware.com>

Relates to https://github.com/theupdateframework/go-tuf/pull/234

Release Notes: <!-- What comments/remarks should we include in the release notes for this change? -->

**Types of changes**:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Description of the changes being introduced by the pull request**:

**Please verify and check that the pull request fulfills the following requirements**:

- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature
