### PR TITLE
chore: remove GITHUB_TOKEN from arnested/go-version-action 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,8 @@ jobs:
         with:
           fetch-depth: 0
       - name: Get Go version
-        uses: arnested/go-version-action@d44f8fbecf1ac5ea61d81603e99dfec9833f592f
+        uses: arnested/go-version-action@75e53ba83545379e9f189ecb73b53b8b3e126c7f
         id: go-version
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Go
         uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,10 +9,8 @@ jobs:
       matrix: ${{ steps.versions.outputs.matrix }}
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
-      - uses: arnested/go-version-action@d44f8fbecf1ac5ea61d81603e99dfec9833f592f
+      - uses: arnested/go-version-action@75e53ba83545379e9f189ecb73b53b8b3e126c7f
         id: versions
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   run:
     strategy:


### PR DESCRIPTION
Hi,

I'm the author of [arnested/go-version-action](https://github.com/marketplace/actions/go-version-action).

The action doesn't need a GITHUB_TOKEN anymore.

Instead of getting the Go releases from git tags using GitHub's API (and thus needing the token to avoid being rate limited) it pulls the versions from https://go.dev/dl/?mode=json&include=all.
