### PR TITLE
ci: Check PR title instead of commits for conventional format

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,18 @@
+name: "Changelog checks"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  conventional-commits-lint-check:
+    name: "Lint PR title"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name:
+        uses: amannn/action-semantic-pull-request@0eb081bc9c35210408951834a444794406eff6f8
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,13 +66,3 @@ jobs:
         uses: golangci/golangci-lint-action@5c56cd6c9dc07901af25baab6f2b0d9f3b7c3018
         with:
           version: v1.45.2
-
-  conventional-commits-lint-check:
-    runs-on: "ubuntu-latest"
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
-        with:
-          fetch-depth: 0
-      - name: Commitsar Action
-        uses: aevea/commitsar@159cec82966ca402a09ae3c185524a5256affa22


### PR DESCRIPTION
Release Notes: PR titles must now use [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) format

**Types of changes**:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [  ] Bug fix (non-breaking change which fixes an issue)
- [  ] New feature (non-breaking change which adds functionality)
- [  ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Description of the changes being introduced by the pull request**:
One of the effects of https://github.com/theupdateframework/go-tuf/pull/234 is that we have to format every commit message using the Conventional Commit format, even though we squash merge PRs, and that commit history is lost. Since the PR title (or in some cases a single commit message) becomes the squashed commit message, that is the place we should check for proper formatting. I swapped in a GitHub action that performs this check.

**Please verify and check that the pull request fulfills the following requirements**:

- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature
