### PR TITLE
ci: Bump golangci-lint to 1.45.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,7 +65,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@5c56cd6c9dc07901af25baab6f2b0d9f3b7c3018
         with:
-          version: v1.45.3
+          version: v1.45.2
 
   conventional-commits-lint-check:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,7 +65,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@5c56cd6c9dc07901af25baab6f2b0d9f3b7c3018
         with:
-          version: v1.44
+          version: v1.45.3
 
   conventional-commits-lint-check:
     runs-on: "ubuntu-latest"


### PR DESCRIPTION
Release Notes: Bump golangci-lint to 1.45.2

**Types of changes**:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Description of the changes being introduced by the pull request**:
Attempts to fix panic in golangci-lint (example: https://github.com/theupdateframework/go-tuf/runs/5889222812?check_suite_focus=true)
Related: https://github.com/golangci/golangci-lint/issues/2374, https://github.com/golangci/golangci-lint/issues/2649

**Please verify and check that the pull request fulfills the following requirements**:

- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature
