### PR TITLE
feat: Implement full support for ECDSA and RSA keys

### DIFF
--- a/data/pkix.go
+++ b/data/pkix.go
@@ -1,0 +1,46 @@
+package data
+
+import (
+	"crypto"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+)
+
+type PKIXPublicKey struct {
+	crypto.PublicKey
+}
+
+func (p *PKIXPublicKey) MarshalJSON() ([]byte, error) {
+	bytes, err := x509.MarshalPKIXPublicKey(p.PublicKey)
+	if err != nil {
+		return nil, err
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: bytes,
+	})
+	return json.Marshal(string(pemBytes))
+}
+
+func (p *PKIXPublicKey) UnmarshalJSON(b []byte) error {
+	var pemValue string
+	if err := json.Unmarshal(b, &pemValue); err != nil {
+		return err
+	}
+	block, _ := pem.Decode([]byte(pemValue))
+	if block == nil {
+		return errors.New("invalid PEM value")
+	}
+	if block.Type != "PUBLIC KEY" {
+		return fmt.Errorf("invalid block type: %s", block.Type)
+	}
+	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return err
+	}
+	p.PublicKey = pub
+	return nil
+}

--- a/data/pkix_test.go
+++ b/data/pkix_test.go
@@ -1,0 +1,42 @@
+package data
+
+import (
+	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+
+	. "gopkg.in/check.v1"
+)
+
+const ecdsaKey = `-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEftgasQA68yvumeXZmcOTSIHKfbmx
+WT1oYuRF0Un3tKxnzip6xAYwlz0Dt96DUh+0P7BruHH2O6s4MiRR9/TuNw==
+-----END PUBLIC KEY-----
+`
+
+type PKIXSuite struct{}
+
+var _ = Suite(&PKIXSuite{})
+
+func (PKIXSuite) TestMarshalJSON(c *C) {
+	block, _ := pem.Decode([]byte(ecdsaKey))
+	key, err := x509.ParsePKIXPublicKey(block.Bytes)
+	c.Assert(err, IsNil)
+	k := PKIXPublicKey{PublicKey: key}
+	buf, err := json.Marshal(&k)
+	c.Assert(err, IsNil)
+	var val string
+	err = json.Unmarshal(buf, &val)
+	c.Assert(err, IsNil)
+	c.Assert(val, Equals, ecdsaKey)
+}
+
+func (PKIXSuite) TestUnmarshalJSON(c *C) {
+	buf, err := json.Marshal(ecdsaKey)
+	c.Assert(err, IsNil)
+	var k PKIXPublicKey
+	err = json.Unmarshal(buf, &k)
+	c.Assert(err, IsNil)
+	c.Assert(k.PublicKey, FitsTypeOf, (*ecdsa.PublicKey)(nil))
+}

--- a/data/types.go
+++ b/data/types.go
@@ -14,18 +14,29 @@ import (
 	"github.com/secure-systems-lab/go-securesystemslib/cjson"
 )
 
+type KeyType string
+
+type KeyScheme string
+
+type HashAlgorithm string
+
 const (
-	KeyIDLength                = sha256.Size * 2
-	KeyTypeEd25519             = "ed25519"
-	KeyTypeECDSA_SHA2_P256     = "ecdsa-sha2-nistp256"
-	KeySchemeEd25519           = "ed25519"
-	KeySchemeECDSA_SHA2_P256   = "ecdsa-sha2-nistp256"
-	KeyTypeRSASSA_PSS_SHA256   = "rsa"
-	KeySchemeRSASSA_PSS_SHA256 = "rsassa-pss-sha256"
+	KeyIDLength = sha256.Size * 2
+
+	KeyTypeEd25519           KeyType = "ed25519"
+	KeyTypeECDSA_SHA2_P256   KeyType = "ecdsa-sha2-nistp256"
+	KeyTypeRSASSA_PSS_SHA256 KeyType = "rsa"
+
+	KeySchemeEd25519           KeyScheme = "ed25519"
+	KeySchemeECDSA_SHA2_P256   KeyScheme = "ecdsa-sha2-nistp256"
+	KeySchemeRSASSA_PSS_SHA256 KeyScheme = "rsassa-pss-sha256"
+
+	HashAlgorithmSHA256 HashAlgorithm = "sha256"
+	HashAlgorithmSHA512 HashAlgorithm = "sha512"
 )
 
 var (
-	HashAlgorithms           = []string{"sha256", "sha512"}
+	HashAlgorithms           = []HashAlgorithm{HashAlgorithmSHA256, HashAlgorithmSHA512}
 	ErrPathsAndPathHashesSet = errors.New("tuf: failed validation of delegated target: paths and path_hash_prefixes are both set")
 )
 
@@ -40,9 +51,9 @@ type Signature struct {
 }
 
 type PublicKey struct {
-	Type       string          `json:"keytype"`
-	Scheme     string          `json:"scheme"`
-	Algorithms []string        `json:"keyid_hash_algorithms,omitempty"`
+	Type       KeyType         `json:"keytype"`
+	Scheme     KeyScheme       `json:"scheme"`
+	Algorithms []HashAlgorithm `json:"keyid_hash_algorithms,omitempty"`
 	Value      json.RawMessage `json:"keyval"`
 
 	ids    []string
@@ -50,9 +61,9 @@ type PublicKey struct {
 }
 
 type PrivateKey struct {
-	Type       string          `json:"keytype"`
-	Scheme     string          `json:"scheme,omitempty"`
-	Algorithms []string        `json:"keyid_hash_algorithms,omitempty"`
+	Type       KeyType         `json:"keytype"`
+	Scheme     KeyScheme       `json:"scheme,omitempty"`
+	Algorithms []HashAlgorithm `json:"keyid_hash_algorithms,omitempty"`
 	Value      json.RawMessage `json:"keyval"`
 }
 

--- a/internal/signer/sort_test.go
+++ b/internal/signer/sort_test.go
@@ -26,7 +26,7 @@ func (s *mockSigner) PublicData() *data.PublicKey {
 	return &data.PublicKey{
 		Type:       "mock",
 		Scheme:     "mock",
-		Algorithms: []string{"mock"},
+		Algorithms: []data.HashAlgorithm{"mock"},
 		Value:      s.value,
 	}
 }

--- a/pkg/keys/ecdsa.go
+++ b/pkg/keys/ecdsa.go
@@ -3,69 +3,139 @@ package keys
 import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
+	"crypto/rand"
 	"crypto/sha256"
-	"encoding/asn1"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
-	"math/big"
+	"fmt"
 
 	"github.com/theupdateframework/go-tuf/data"
 )
 
 func init() {
-	VerifierMap.Store(data.KeyTypeECDSA_SHA2_P256, NewEcdsaVerifier)
+	VerifierMap.Store(data.KeyTypeECDSA_SHA2_P256, newEcdsaVerifier)
+	SignerMap.Store(data.KeyTypeECDSA_SHA2_P256, newEcdsaSigner)
 }
 
-func NewEcdsaVerifier() Verifier {
-	return &p256Verifier{}
+func newEcdsaVerifier() Verifier {
+	return &ecdsaVerifier{}
 }
 
-type ecdsaSignature struct {
-	R, S *big.Int
+func newEcdsaSigner() Signer {
+	return &ecdsaSigner{}
 }
 
-type p256Verifier struct {
-	PublicKey data.HexBytes `json:"public"`
+type ecdsaVerifier struct {
+	PublicKey *data.PKIXPublicKey `json:"public"`
+	ecdsaKey  *ecdsa.PublicKey
 	key       *data.PublicKey
 }
 
-func (p *p256Verifier) Public() string {
-	return p.PublicKey.String()
+func (p *ecdsaVerifier) Public() string {
+	r, _ := x509.MarshalPKIXPublicKey(p.ecdsaKey)
+	return string(r)
 }
 
-func (p *p256Verifier) Verify(msg, sigBytes []byte) error {
-	x, y := elliptic.Unmarshal(elliptic.P256(), p.PublicKey)
-	k := &ecdsa.PublicKey{
-		Curve: elliptic.P256(),
-		X:     x,
-		Y:     y,
-	}
-
-	var sig ecdsaSignature
-	if _, err := asn1.Unmarshal(sigBytes, &sig); err != nil {
-		return err
-	}
-
+func (p *ecdsaVerifier) Verify(msg, sigBytes []byte) error {
 	hash := sha256.Sum256(msg)
 
-	if !ecdsa.Verify(k, hash[:], sig.R, sig.S) {
-		return errors.New("tuf: ecdsa signature verification failed")
+	if !ecdsa.VerifyASN1(p.ecdsaKey, hash[:], sigBytes) {
+		return errors.New("signature verification failed")
 	}
 	return nil
 }
 
-func (p *p256Verifier) MarshalPublicKey() *data.PublicKey {
+func (p *ecdsaVerifier) MarshalPublicKey() *data.PublicKey {
 	return p.key
 }
 
-func (p *p256Verifier) UnmarshalPublicKey(key *data.PublicKey) error {
+func (p *ecdsaVerifier) UnmarshalPublicKey(key *data.PublicKey) error {
 	if err := json.Unmarshal(key.Value, p); err != nil {
 		return err
 	}
-	x, _ := elliptic.Unmarshal(elliptic.P256(), p.PublicKey)
-	if x == nil {
-		return errors.New("tuf: invalid ecdsa public key point")
+	ecdsaKey, ok := p.PublicKey.PublicKey.(*ecdsa.PublicKey)
+	if !ok {
+		return fmt.Errorf("invalid public key")
 	}
+	p.ecdsaKey = ecdsaKey
 	p.key = key
 	return nil
+}
+
+type ecdsaSigner struct {
+	*ecdsa.PrivateKey
+}
+
+type ecdsaPrivateKeyValue struct {
+	Private string              `json:"private"`
+	Public  *data.PKIXPublicKey `json:"public"`
+}
+
+func (s *ecdsaSigner) PublicData() *data.PublicKey {
+	keyValBytes, _ := json.Marshal(ecdsaVerifier{PublicKey: &data.PKIXPublicKey{PublicKey: s.Public()}})
+	return &data.PublicKey{
+		Type:       data.KeyTypeECDSA_SHA2_P256,
+		Scheme:     data.KeySchemeECDSA_SHA2_P256,
+		Algorithms: data.HashAlgorithms,
+		Value:      keyValBytes,
+	}
+}
+
+func (s *ecdsaSigner) SignMessage(message []byte) ([]byte, error) {
+	hash := sha256.Sum256(message)
+	return ecdsa.SignASN1(rand.Reader, s.PrivateKey, hash[:])
+}
+
+func (s *ecdsaSigner) MarshalPrivateKey() (*data.PrivateKey, error) {
+	priv, err := x509.MarshalECPrivateKey(s.PrivateKey)
+	if err != nil {
+		return nil, err
+	}
+	pemKey := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: priv})
+	val, err := json.Marshal(ecdsaPrivateKeyValue{
+		Private: string(pemKey),
+		Public:  &data.PKIXPublicKey{PublicKey: s.Public()},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &data.PrivateKey{
+		Type:       data.KeyTypeECDSA_SHA2_P256,
+		Scheme:     data.KeySchemeECDSA_SHA2_P256,
+		Algorithms: data.HashAlgorithms,
+		Value:      val,
+	}, nil
+}
+
+func (s *ecdsaSigner) UnmarshalPrivateKey(key *data.PrivateKey) error {
+	val := ecdsaPrivateKeyValue{}
+	if err := json.Unmarshal(key.Value, &val); err != nil {
+		return err
+	}
+	block, _ := pem.Decode([]byte(val.Private))
+	if block == nil {
+		return errors.New("invalid PEM value")
+	}
+	if block.Type != "EC PRIVATE KEY" {
+		return fmt.Errorf("invalid block type: %s", block.Type)
+	}
+	k, err := x509.ParseECPrivateKey(block.Bytes)
+	if err != nil {
+		return err
+	}
+	if k.Curve != elliptic.P256() {
+		return errors.New("invalid ecdsa curve")
+	}
+	s.PrivateKey = k
+	return nil
+}
+
+func GenerateEcdsaKey() (*ecdsaSigner, error) {
+	privkey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	return &ecdsaSigner{privkey}, nil
 }

--- a/pkg/keys/ecdsa_test.go
+++ b/pkg/keys/ecdsa_test.go
@@ -5,12 +5,12 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-type RsaSuite struct{}
+type EcdsaSuite struct{}
 
-var _ = Suite(&RsaSuite{})
+var _ = Suite(EcdsaSuite{})
 
-func (RsaSuite) TestSignVerify(c *C) {
-	signer, err := GenerateRsaKey()
+func (EcdsaSuite) TestSignVerify(c *C) {
+	signer, err := GenerateEcdsaKey()
 	c.Assert(err, IsNil)
 	msg := []byte("foo")
 	sig, err := signer.SignMessage(msg)
@@ -21,8 +21,8 @@ func (RsaSuite) TestSignVerify(c *C) {
 	c.Assert(pubKey.Verify(msg, sig), IsNil)
 }
 
-func (RsaSuite) TestMarshalUnmarshal(c *C) {
-	signer, err := GenerateRsaKey()
+func (EcdsaSuite) TestMarshalUnmarshalPublicKey(c *C) {
+	signer, err := GenerateEcdsaKey()
 	c.Assert(err, IsNil)
 	publicData := signer.PublicData()
 	pubKey, err := GetVerifier(publicData)
@@ -30,13 +30,13 @@ func (RsaSuite) TestMarshalUnmarshal(c *C) {
 	c.Assert(pubKey.MarshalPublicKey(), DeepEquals, publicData)
 }
 
-func (RsaSuite) TestMarshalUnmarshalPrivateKey(c *C) {
-	signer, err := GenerateRsaKey()
+func (EcdsaSuite) TestMarshalUnmarshalPrivateKey(c *C) {
+	signer, err := GenerateEcdsaKey()
 	c.Assert(err, IsNil)
 	privateData, err := signer.MarshalPrivateKey()
 	c.Assert(err, IsNil)
-	c.Assert(privateData.Type, Equals, data.KeyTypeRSASSA_PSS_SHA256)
-	c.Assert(privateData.Scheme, Equals, data.KeySchemeRSASSA_PSS_SHA256)
+	c.Assert(privateData.Type, Equals, data.KeyTypeECDSA_SHA2_P256)
+	c.Assert(privateData.Scheme, Equals, data.KeySchemeECDSA_SHA2_P256)
 	c.Assert(privateData.Algorithms, DeepEquals, data.HashAlgorithms)
 	s, err := GetSigner(privateData)
 	c.Assert(err, IsNil)

--- a/pkg/keys/ed25519.go
+++ b/pkg/keys/ed25519.go
@@ -61,10 +61,6 @@ type Ed25519PrivateKeyValue struct {
 
 type ed25519Signer struct {
 	ed25519.PrivateKey
-
-	keyType       string
-	keyScheme     string
-	keyAlgorithms []string
 }
 
 func GenerateEd25519Key() (*ed25519Signer, error) {
@@ -76,19 +72,13 @@ func GenerateEd25519Key() (*ed25519Signer, error) {
 		return nil, err
 	}
 	return &ed25519Signer{
-		PrivateKey:    ed25519.PrivateKey(data.HexBytes(private)),
-		keyType:       data.KeyTypeEd25519,
-		keyScheme:     data.KeySchemeEd25519,
-		keyAlgorithms: data.HashAlgorithms,
+		PrivateKey: ed25519.PrivateKey(data.HexBytes(private)),
 	}, nil
 }
 
 func NewEd25519Signer(keyValue Ed25519PrivateKeyValue) *ed25519Signer {
 	return &ed25519Signer{
-		PrivateKey:    ed25519.PrivateKey(data.HexBytes(keyValue.Private)),
-		keyType:       data.KeyTypeEd25519,
-		keyScheme:     data.KeySchemeEd25519,
-		keyAlgorithms: data.HashAlgorithms,
+		PrivateKey: ed25519.PrivateKey(data.HexBytes(keyValue.Private)),
 	}
 }
 
@@ -105,9 +95,9 @@ func (e *ed25519Signer) MarshalPrivateKey() (*data.PrivateKey, error) {
 		return nil, err
 	}
 	return &data.PrivateKey{
-		Type:       e.keyType,
-		Scheme:     e.keyScheme,
-		Algorithms: e.keyAlgorithms,
+		Type:       data.KeyTypeEd25519,
+		Scheme:     data.KeySchemeEd25519,
+		Algorithms: data.HashAlgorithms,
 		Value:      valueBytes,
 	}, nil
 }
@@ -118,10 +108,7 @@ func (e *ed25519Signer) UnmarshalPrivateKey(key *data.PrivateKey) error {
 		return err
 	}
 	*e = ed25519Signer{
-		PrivateKey:    ed25519.PrivateKey(data.HexBytes(keyValue.Private)),
-		keyType:       key.Type,
-		keyScheme:     key.Scheme,
-		keyAlgorithms: key.Algorithms,
+		PrivateKey: ed25519.PrivateKey(data.HexBytes(keyValue.Private)),
 	}
 	return nil
 }
@@ -129,9 +116,9 @@ func (e *ed25519Signer) UnmarshalPrivateKey(key *data.PrivateKey) error {
 func (e *ed25519Signer) PublicData() *data.PublicKey {
 	keyValBytes, _ := json.Marshal(ed25519Verifier{PublicKey: []byte(e.PrivateKey.Public().(ed25519.PublicKey))})
 	return &data.PublicKey{
-		Type:       e.keyType,
-		Scheme:     e.keyScheme,
-		Algorithms: e.keyAlgorithms,
+		Type:       data.KeyTypeEd25519,
+		Scheme:     data.KeySchemeEd25519,
+		Algorithms: data.HashAlgorithms,
 		Value:      keyValBytes,
 	}
 }

--- a/pkg/keys/ed25519.go
+++ b/pkg/keys/ed25519.go
@@ -11,15 +11,15 @@ import (
 )
 
 func init() {
-	SignerMap.Store(data.KeySchemeEd25519, NewP256Signer)
-	VerifierMap.Store(data.KeySchemeEd25519, NewP256Verifier)
+	SignerMap.Store(data.KeyTypeEd25519, newEd25519Signer)
+	VerifierMap.Store(data.KeyTypeEd25519, newEd25519Verifier)
 }
 
-func NewP256Signer() Signer {
+func newEd25519Signer() Signer {
 	return &ed25519Signer{}
 }
 
-func NewP256Verifier() Verifier {
+func newEd25519Verifier() Verifier {
 	return &ed25519Verifier{}
 }
 

--- a/pkg/keys/ed25519_test.go
+++ b/pkg/keys/ed25519_test.go
@@ -19,7 +19,7 @@ func (Ed25519Suite) TestUnmarshalEd25519(c *C) {
 		Algorithms: data.HashAlgorithms,
 		Value:      badKeyValue,
 	}
-	verifier := NewP256Verifier()
+	verifier := newEd25519Verifier()
 	c.Assert(verifier.UnmarshalPublicKey(badKey), ErrorMatches, "json: cannot unmarshal.*")
 }
 

--- a/pkg/keys/keys_test.go
+++ b/pkg/keys/keys_test.go
@@ -3,6 +3,7 @@ package keys
 import (
 	"testing"
 
+	"github.com/theupdateframework/go-tuf/data"
 	. "gopkg.in/check.v1"
 )
 
@@ -32,7 +33,7 @@ func (KeysSuite) TestSignerKeyIDs(c *C) {
 	c.Assert(err, IsNil)
 	privKey, err = signer.MarshalPrivateKey()
 	c.Assert(err, IsNil)
-	privKey.Algorithms = []string{}
+	privKey.Algorithms = []data.HashAlgorithm{}
 	err = signer.UnmarshalPrivateKey(privKey)
 	c.Assert(err, IsNil)
 }

--- a/pkg/keys/rsa.go
+++ b/pkg/keys/rsa.go
@@ -9,37 +9,32 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"errors"
+	"fmt"
 
 	"github.com/theupdateframework/go-tuf/data"
 )
 
 func init() {
-	VerifierMap.Store(data.KeyTypeRSASSA_PSS_SHA256, NewRsaVerifier)
-	SignerMap.Store(data.KeyTypeRSASSA_PSS_SHA256, NewRsaSigner)
+	VerifierMap.Store(data.KeyTypeRSASSA_PSS_SHA256, newRsaVerifier)
+	SignerMap.Store(data.KeyTypeRSASSA_PSS_SHA256, newRsaSigner)
 }
 
-func NewRsaVerifier() Verifier {
+func newRsaVerifier() Verifier {
 	return &rsaVerifier{}
 }
 
-func NewRsaSigner() Signer {
+func newRsaSigner() Signer {
 	return &rsaSigner{}
 }
 
 type rsaVerifier struct {
-	PublicKey string `json:"public"`
+	PublicKey *data.PKIXPublicKey `json:"public"`
 	rsaKey    *rsa.PublicKey
 	key       *data.PublicKey
 }
 
 func (p *rsaVerifier) Public() string {
-	// Unique public key identifier, use a uniform encodng
-	r, err := x509.MarshalPKIXPublicKey(p.rsaKey)
-	if err != nil {
-		// This shouldn't happen with a valid rsa key, but fallback on the
-		// JSON public key string
-		return string(p.PublicKey)
-	}
+	r, _ := x509.MarshalPKIXPublicKey(p.rsaKey)
 	return string(r)
 }
 
@@ -57,53 +52,26 @@ func (p *rsaVerifier) UnmarshalPublicKey(key *data.PublicKey) error {
 	if err := json.Unmarshal(key.Value, p); err != nil {
 		return err
 	}
-	var err error
-	p.rsaKey, err = parseKey(p.PublicKey)
-	if err != nil {
-		return err
+	rsaKey, ok := p.PublicKey.PublicKey.(*rsa.PublicKey)
+	if !ok {
+		return fmt.Errorf("invalid public key")
 	}
+	p.rsaKey = rsaKey
 	p.key = key
 	return nil
-}
-
-// parseKey tries to parse a PEM []byte slice by attempting PKCS1 and PKIX in order.
-func parseKey(data string) (*rsa.PublicKey, error) {
-	block, _ := pem.Decode([]byte(data))
-	if block == nil {
-		return nil, errors.New("tuf: pem decoding public key failed")
-	}
-	rsaPub, err := x509.ParsePKCS1PublicKey(block.Bytes)
-	if err == nil {
-		return rsaPub, nil
-	}
-	key, err := x509.ParsePKIXPublicKey(block.Bytes)
-	if err == nil {
-		rsaPub, ok := key.(*rsa.PublicKey)
-		if !ok {
-			return nil, errors.New("tuf: invalid rsa key")
-		}
-		return rsaPub, nil
-	}
-	return nil, errors.New("tuf: error unmarshalling rsa key")
 }
 
 type rsaSigner struct {
 	*rsa.PrivateKey
 }
 
-type rsaPublic struct {
-	// PEM encoded public key.
-	PublicKey string `json:"public"`
+type rsaPrivateKeyValue struct {
+	Private string              `json:"private"`
+	Public  *data.PKIXPublicKey `json:"public"`
 }
 
 func (s *rsaSigner) PublicData() *data.PublicKey {
-	pub, _ := x509.MarshalPKIXPublicKey(s.Public().(*rsa.PublicKey))
-	pubBytes := pem.EncodeToMemory(&pem.Block{
-		Type:  "RSA PUBLIC KEY",
-		Bytes: pub,
-	})
-
-	keyValBytes, _ := json.Marshal(rsaPublic{PublicKey: string(pubBytes)})
+	keyValBytes, _ := json.Marshal(rsaVerifier{PublicKey: &data.PKIXPublicKey{PublicKey: s.Public()}})
 	return &data.PublicKey{
 		Type:       data.KeyTypeRSASSA_PSS_SHA256,
 		Scheme:     data.KeySchemeRSASSA_PSS_SHA256,
@@ -122,11 +90,41 @@ func (s *rsaSigner) ContainsID(id string) bool {
 }
 
 func (s *rsaSigner) MarshalPrivateKey() (*data.PrivateKey, error) {
-	return nil, errors.New("not implemented for test")
+	priv := x509.MarshalPKCS1PrivateKey(s.PrivateKey)
+	pemKey := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: priv})
+	val, err := json.Marshal(rsaPrivateKeyValue{
+		Private: string(pemKey),
+		Public:  &data.PKIXPublicKey{PublicKey: s.Public()},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &data.PrivateKey{
+		Type:       data.KeyTypeRSASSA_PSS_SHA256,
+		Scheme:     data.KeySchemeRSASSA_PSS_SHA256,
+		Algorithms: data.HashAlgorithms,
+		Value:      val,
+	}, nil
 }
 
 func (s *rsaSigner) UnmarshalPrivateKey(key *data.PrivateKey) error {
-	return errors.New("not implemented for test")
+	val := rsaPrivateKeyValue{}
+	if err := json.Unmarshal(key.Value, &val); err != nil {
+		return err
+	}
+	block, _ := pem.Decode([]byte(val.Private))
+	if block == nil {
+		return errors.New("invalid PEM value")
+	}
+	if block.Type != "RSA PRIVATE KEY" {
+		return fmt.Errorf("invalid block type: %s", block.Type)
+	}
+	k, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err != nil {
+		return err
+	}
+	s.PrivateKey = k
+	return nil
 }
 
 func GenerateRsaKey() (*rsaSigner, error) {

--- a/verify/db.go
+++ b/verify/db.go
@@ -58,7 +58,7 @@ func (db *DB) AddKey(id string, k *data.PublicKey) error {
 	}
 	verifier, err := keys.GetVerifier(k)
 	if err != nil {
-		return ErrInvalidKey
+		return err // ErrInvalidKey
 	}
 	db.verifiers[id] = verifier
 	return nil

--- a/verify/db_test.go
+++ b/verify/db_test.go
@@ -36,7 +36,7 @@ func TestDelegationsDB(t *testing.T) {
 		{
 			testName: "invalid keys",
 			delegations: &data.Delegations{Keys: map[string]*data.PublicKey{
-				"a": {Type: data.KeySchemeEd25519},
+				"a": {Type: data.KeyTypeEd25519},
 			}},
 			initErr: ErrWrongID{},
 		},

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -31,12 +31,11 @@ type ecdsaSigner struct {
 }
 
 type ecdsaPublic struct {
-	PublicKey data.HexBytes `json:"public"`
+	PublicKey *data.PKIXPublicKey `json:"public"`
 }
 
 func (s ecdsaSigner) PublicData() *data.PublicKey {
-	pub := s.Public().(*ecdsa.PublicKey)
-	keyValBytes, _ := json.Marshal(ecdsaPublic{PublicKey: elliptic.Marshal(pub.Curve, pub.X, pub.Y)})
+	keyValBytes, _ := json.Marshal(ecdsaPublic{PublicKey: &data.PKIXPublicKey{PublicKey: s.Public()}})
 	return &data.PublicKey{
 		Type:       data.KeyTypeECDSA_SHA2_P256,
 		Scheme:     data.KeySchemeECDSA_SHA2_P256,


### PR DESCRIPTION
Release Notes:

- Implements full support for ECDSA and RSA key types.
- When generating a key with the `gen-key` sub command, the `--type` flag can be specified to select a key type (according the the types in https://theupdateframework.github.io/specification/latest/#keytype). Defaults to `ed25519` keys.

**Types of changes**:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Description of the changes being introduced by the pull request**:

Previously support for ECDSA and RSA keys was only partially implemented:
- Only the verifier/public key type was implemented for ECDSA.
- ECDSA public keys were parsed as the hex encoding of the raw point serialised as ASN.1 . The TUF specification states that they should be encoded as PEM https://theupdateframework.github.io/specification/latest/#keyval-ecdsa-public.
- The RSA signer was not fully implemented, the marshal and unmarshal methods returned not implemented errors.
- The RSA public key mixed up the PEM encoding, it encoded as PKIX, but then set the header to `RSA PUBLIC KEY` which is used for PKCS1 encoding. While the spec doesn't specify which encoding should be used (and just specifies "PEM"), the python reference implementation uses PKIX for both ECDSA and RSA keys.
- The RSA verifier attempted to parse the public key as PKCS1 and PKIX. While the spec does not make this clear, the python implementation only uses PKIX.
- The `gen-key` subcommand does not allow key types to be specified, added a `--type` flag to allow the user to select the key type to be generated.

As well as the above fixes, some additional improvements to the library were made:
- Defined new go types for `KeyType`, `KeyScheme` and `HashAlgorithm`, rather than just using strings, and fixed a few places where the key type and scheme had been mixed up. 
- Added a new `data.PKIXPublicKey` type which abstracts away a lot of the boiler plate for marshalling/unmarshalling public keys.

I opted not to maintain backwards compatibility as there is currently no implementation to generate ECDSA or RSA keys, and the go-tuf implementation wouldn't have worked with keys serialised according the the TUF specification, so there didn't seem any benefit to maintaining this functionality.

**Please verify and check that the pull request fulfills the following requirements**:

- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature
