### PR TITLE
chore: bump golangci-lint timeout

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,3 +66,4 @@ jobs:
         uses: golangci/golangci-lint-action@5c56cd6c9dc07901af25baab6f2b0d9f3b7c3018
         with:
           version: v1.45.2
+          args: --timeout 3m 


### PR DESCRIPTION
We've been seeing test failures: https://github.com/theupdateframework/go-tuf/runs/6215906951?check_suite_focus=true

See: https://github.com/golangci/golangci-lint-action/issues/297

Please fill in the fields below to submit a pull request.  The more information that is provided, the better.

Fixes N/A
Release Notes: N/A

**Types of changes**:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [  ] New feature (non-breaking change which adds functionality)
- [  ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Description of the changes being introduced by the pull request**:

**Please verify and check that the pull request fulfills the following requirements**:

- [-] Tests have been added for the bug fix or new feature
- [-] Docs have been added for the bug fix or new feature
