### PR TITLE
feat: add workflow responsible for notifying of new TUF spec release

### DIFF
--- a/.github/workflows/specification-version-check.yml
+++ b/.github/workflows/specification-version-check.yml
@@ -6,6 +6,9 @@ name: Specification version check
 jobs:
   # Get the latest TUF specification release and open an issue (if needed)
   specification-bump-check:
+    permissions:
+      contents: read
+      issues: write
     uses: theupdateframework/specification/.github/workflows/check-latest-spec-version.yml@master
     with:
       tuf-version: "v1.0.29" # Should be updated to the according version either manually or extracted automatically as how it's done in python-tuf

--- a/.github/workflows/specification-version-check.yml
+++ b/.github/workflows/specification-version-check.yml
@@ -1,0 +1,11 @@
+on:
+  schedule:
+    - cron: "0 13 * * *"
+  workflow_dispatch:
+name: Specification version check
+jobs:
+  # Get the latest TUF specification release and open an issue (if needed)
+  specification-bump-check:
+    uses: theupdateframework/specification/.github/workflows/check-latest-spec-version.yml@master
+    with:
+      tuf-version: "v1.0.29" # Should be updated to the according version either manually or extracted automatically as how it's done in python-tuf

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -17,12 +17,12 @@ Speedy communication makes contributors happy!
 Versioning:
 
 - go-tuf releases follow [SemVer](https://semver.org/) with the following modification:
-    - While go-tuf is pre-1.0, increment the minor version for any breaking changes (in SemVer, there are no guarantees about API stability).
+  - While go-tuf is pre-1.0, increment the minor version for any breaking changes (in SemVer, there are no guarantees about API stability).
 - Releases should be tagged in this repository as usual in Go ([Publishing a module](https://go.dev/doc/modules/publishing)).
 
 Project management:
 
-- Try to keep issues up-to-date with status updates! 
+- Try to keep issues up-to-date with status updates!
   - Feel free to ping open issues to check on them.
   - Use the "assignee" field to indicate when you are working on an issue.
   - Use GitHub issue labels to describe the issue (exact labels are still changing, so just look through and add those that seem like a good fit).
@@ -45,4 +45,9 @@ Pre-merge (check everything again before hitting the merge button!):
   - This may be waived for PRs which only update docs or comments, or trivial changes to tests.
 - Make sure that the PR title, commit message, and description are updated if the PR changes significantly during review.
 
+New version of the TUF specification:
 
+- There's an automated workflow which monitors and opens an issue in case there's newer version of the [TUF specification](https://theupdateframework.github.io/specification/latest/)
+- Closing the issue should happen after completing the following steps:
+  - Review the changes to the specification and make sure they're addressed (possibly requires breaking out a few relevant issues).
+  - Bump the `tuf-version` in the `.github/workflows/specification-version-check.yml` workflow.


### PR DESCRIPTION
Signed-off-by: Radoslav Dimitrov <dimitrovr@vmware.com>

Please fill in the fields below to submit a pull request.  The more information that is provided, the better.

Fixes #283

Release Notes: <!-- What comments/remarks should we include in the release notes for this change? -->

**Types of changes**:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Description of the changes being introduced by the pull request**:

The following PR adds a workflow that keeps track and creates an issue for notifying of new TUF specification releases. 

For the time being, there's no decision on stating the version of the TUF specification which go-tuf complies with. Until this is addressed, the version of the spec which will be used for the verification is added manually. 

**Note:** Dependent on - https://github.com/theupdateframework/specification/pull/224

**Please verify and check that the pull request fulfills the following requirements**:

- [ ] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature
