### PR TITLE
Repo: Check root metadata verification before snapshotting

### DIFF
--- a/repo.go
+++ b/repo.go
@@ -1280,6 +1280,11 @@ func (r *Repo) SnapshotWithExpires(expires time.Time) error {
 		return err
 	}
 
+	// Verify root metadata before verifying signatures on role metadata.
+	if err := r.verifySignatures("root.json"); err != nil {
+		return err
+	}
+
 	for _, metaName := range r.snapshotMetadata() {
 		if err := r.verifySignatures(metaName); err != nil {
 			return err


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Details in https://github.com/theupdateframework/go-tuf/issues/292
See https://github.com/sigstore/root-signing/issues/238

Because `root.json` is not pinned in `snapshot.json`, it's metadata is not verified before Snapshotting. For robustness, we should verify the root.json is signed correctly, because we're using DB role data from root to verify other manifests that are pinned, e.g. targets.

I'm open to having this just be a warning, because I don't see this mentioned in the spec, but overall repo management lacks in the spec.

Please fill in the fields below to submit a pull request.  The more information that is provided, the better.

Fixes #<Issue>
Release Notes: <!-- What comments/remarks should we include in the release notes for this change? -->

**Types of changes**:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [  ] Bug fix (non-breaking change which fixes an issue)
- [  ] New feature (non-breaking change which adds functionality)
- [  ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Description of the changes being introduced by the pull request**:

**Please verify and check that the pull request fulfills the following requirements**:

- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature
