### PR TITLE
fix: verify length and hashes of fetched bytes before parsing

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -691,11 +691,16 @@ func (c *Client) downloadMetaFromTimestamp(name string, m data.TimestampFileMeta
 		return nil, err
 	}
 
+	// 5.2.2. – Check length and hashes of fetched bytes *before* parsing metadata
+	if err := util.BytesMatchLenAndHashes(b, m.Length, m.Hashes); err != nil {
+		return nil, ErrDownloadFailed{name, err}
+	}
+
 	meta, err := util.GenerateTimestampFileMeta(bytes.NewReader(b), m.HashAlgorithms()...)
 	if err != nil {
 		return nil, err
 	}
-	// 5.5.2 and 5.5.4 - Check against timestamp role's snapshot hash and version
+	// 5.5.4 - Check against timestamp role's snapshot hash and version
 	if err := util.TimestampFileMetaEqual(meta, m); err != nil {
 		return nil, ErrDownloadFailed{name, err}
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -683,10 +683,12 @@ func (c *Client) downloadMetaFromSnapshot(name string, m data.SnapshotFileMeta) 
 	if err != nil {
 		return nil, err
 	}
-	// 5.6.4 - Check against snapshot role's targets hash and version
-	if err := util.SnapshotFileMetaEqual(meta, m); err != nil {
+
+	// 5.6.4 - Check against snapshot role's version
+	if err := util.VersionEqual(meta.Version, m.Version); err != nil {
 		return nil, ErrDownloadFailed{name, err}
 	}
+
 	return b, nil
 }
 
@@ -705,10 +707,12 @@ func (c *Client) downloadMetaFromTimestamp(name string, m data.TimestampFileMeta
 	if err != nil {
 		return nil, err
 	}
-	// 5.5.4 - Check against timestamp role's snapshot hash and version
-	if err := util.TimestampFileMetaEqual(meta, m); err != nil {
+
+	// 5.5.4 - Check against timestamp role's version
+	if err := util.VersionEqual(meta.Version, m.Version); err != nil {
 		return nil, ErrDownloadFailed{name, err}
 	}
+
 	return b, nil
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -674,11 +674,16 @@ func (c *Client) downloadMetaFromSnapshot(name string, m data.SnapshotFileMeta) 
 		return nil, err
 	}
 
+	// 5.6.2 – Check length and hashes of fetched bytes *before* parsing metadata
+	if err := util.BytesMatchLenAndHashes(b, m.Length, m.Hashes); err != nil {
+		return nil, ErrDownloadFailed{name, err}
+	}
+
 	meta, err := util.GenerateSnapshotFileMeta(bytes.NewReader(b), m.HashAlgorithms()...)
 	if err != nil {
 		return nil, err
 	}
-	// 5.6.2 and 5.6.4 - Check against snapshot role's targets hash and version
+	// 5.6.4 - Check against snapshot role's targets hash and version
 	if err := util.SnapshotFileMetaEqual(meta, m); err != nil {
 		return nil, ErrDownloadFailed{name, err}
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -92,24 +92,23 @@ func BytesMatchLenAndHashes(fetched []byte, length int64, hashes data.Hashes) er
 		return ErrWrongLength{length, flen}
 	}
 
-	if len(hashes) != 0 {
-		for alg, expected := range hashes {
-			var h hash.Hash
-			switch alg {
-			case "sha256":
-				h = sha256.New()
-			case "sha512":
-				h = sha512.New()
-			default:
-				return ErrUnknownHashAlgorithm{alg}
-			}
-			h.Write(fetched)
-			hash := h.Sum(nil)
-			if !hmac.Equal(hash, expected) {
-				return ErrWrongHash{alg, expected, hash}
-			}
+	for alg, expected := range hashes {
+		var h hash.Hash
+		switch alg {
+		case "sha256":
+			h = sha256.New()
+		case "sha512":
+			h = sha512.New()
+		default:
+			return ErrUnknownHashAlgorithm{alg}
+		}
+		h.Write(fetched)
+		hash := h.Sum(nil)
+		if !hmac.Equal(hash, expected) {
+			return ErrWrongHash{alg, expected, hash}
 		}
 	}
+
 	return nil
 }
 

--- a/util/util.go
+++ b/util/util.go
@@ -129,7 +129,7 @@ func hashEqual(actual data.Hashes, expected data.Hashes) error {
 	return nil
 }
 
-func versionEqual(actual int64, expected int64) error {
+func VersionEqual(actual int64, expected int64) error {
 	if actual != expected {
 		return ErrWrongVersion{expected, actual}
 	}
@@ -152,7 +152,7 @@ func SnapshotFileMetaEqual(actual data.SnapshotFileMeta, expected data.SnapshotF
 		}
 	}
 	// 5.6.4 - Check against snapshot role's snapshot version
-	if err := versionEqual(actual.Version, expected.Version); err != nil {
+	if err := VersionEqual(actual.Version, expected.Version); err != nil {
 		return err
 	}
 
@@ -176,7 +176,7 @@ func TimestampFileMetaEqual(actual data.TimestampFileMeta, expected data.Timesta
 		}
 	}
 	// 5.5.4 - Check against timestamp role's snapshot version
-	if err := versionEqual(actual.Version, expected.Version); err != nil {
+	if err := VersionEqual(actual.Version, expected.Version); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Fixes #233
Release Notes: <!-- What comments/remarks should we include in the release notes for this change? -->
Check hashes and length of downloaded snapshot and targets metadata before parsing.

**Types of changes**:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Description of the changes being introduced by the pull request**:
Better match the specification by performing checks against length and hashes on the downloaded bytes before parsing the bytes into a FileMeta.

**Please verify and check that the pull request fulfills the following requirements**:

- [x] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature
