### PR TITLE
fix: remove extraneous snapshotted metadata

### DIFF
--- a/repo.go
+++ b/repo.go
@@ -1277,6 +1277,7 @@ func (r *Repo) SnapshotWithExpires(expires time.Time) error {
 		return err
 	}
 
+	snapshot.Meta = data.SnapshotFiles{}
 	for _, metaName := range r.snapshotMetadata() {
 		if err := r.verifySignatures(metaName); err != nil {
 			return err

--- a/repo_test.go
+++ b/repo_test.go
@@ -2632,8 +2632,7 @@ func (rs *RepoSuite) TestSnapshotWithInvalidRoot(c *C) {
 	c.Assert(r.Commit(), IsNil)
 }
 
-// Regression test: Snapshotting after removing a delegation should remove the
-// removed delegation hash.
+// Regression test: Snapshotting should remove old snapshot metadata.
 func (rs *RepoSuite) TestSnapshotAfterRemoveDelegation(c *C) {
 	tmp := newTmpDir(c)
 	local := FileSystemStore(tmp.path, nil)


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Please fill in the fields below to submit a pull request.  The more information that is provided, the better.

Fixes #<Issue>
Release Notes: <!-- What comments/remarks should we include in the release notes for this change? -->

**Types of changes**:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [  ] New feature (non-breaking change which adds functionality)
- [  ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Description of the changes being introduced by the pull request**:
Before, go-tuf would add `root.json` metadata to the snapshot manifest. Later, it was removed https://github.com/theupdateframework/go-tuf/issues/203. However, snapshotting didn't reset the snapshotmeta, so this left old metadata on the `root.json`: see https://github.com/sigstore/root-signing/pull/320#discussion_r920174081

**Please verify and check that the pull request fulfills the following requirements**:

- [ x] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature
