### PR TITLE
feat: Add new `status` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ Adds signatures (the output of `tuf sign-payload`) to the given role metadata fi
 
 If the signature does not verify, it will not be added.
 
+#### `tuf status --valid-at <date> <role>`
+
+Check if the role's metadata will be expired on the given date. 
+
 #### Usage of environment variables
 
 The `tuf` CLI supports receiving passphrases via environment variables in

--- a/cmd/tuf/main.go
+++ b/cmd/tuf/main.go
@@ -40,6 +40,7 @@ Commands:
   add-signatures     Adds signatures generated offline
   sign               Sign a role's metadata file
   sign-payload       Sign a file from the "payload" command.
+  status             Check if a role's metadata has expired
   commit             Commit staged files to the repository
   regenerate         Recreate the targets metadata file [Not supported yet]
   set-threshold      Sets the threshold for a role

--- a/cmd/tuf/status.go
+++ b/cmd/tuf/status.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/flynn/go-docopt"
+	"github.com/theupdateframework/go-tuf"
+)
+
+func init() {
+	register("status", cmdStatus, `
+usage: tuf status --valid-at=<date> <role>
+
+Check if the role's metadata will be expired on the given date.
+
+The command's exit status will be 1 if the role has expired, 0 otherwise.
+
+Example:
+  # See if timestamp metadata is expiring in the next hour:
+  tuf status --valid-at "$(date -d '+1 hour')" timestamp || echo "Time to refresh"
+
+Options:
+  --valid-at=<date>   Must be in one of the formats:
+                      * RFC3339  - 2006-01-02T15:04:05Z07:00
+                      * RFC822   - 02 Jan 06 15:04 MST
+                      * UnixDate - Mon Jan _2 15:04:05 MST 2006
+`)
+}
+
+func cmdStatus(args *docopt.Args, repo *tuf.Repo) error {
+	role := args.String["<role>"]
+	validAtStr := args.String["--valid-at"]
+
+	formats := []string{
+		time.RFC3339,
+		time.RFC822,
+		time.UnixDate,
+	}
+	for _, fmt := range formats {
+		validAt, err := time.Parse(fmt, validAtStr)
+		if err == nil {
+			return repo.CheckRoleUnexpired(role, validAt)
+		}
+	}
+	return fmt.Errorf("failed to parse --valid-at arg")
+}

--- a/repo.go
+++ b/repo.go
@@ -1555,3 +1555,39 @@ func (r *Repo) Payload(roleFilename string) ([]byte, error) {
 
 	return p, nil
 }
+
+func (r *Repo) CheckRoleUnexpired(role string, validAt time.Time) error {
+	var expires time.Time
+	switch role {
+	case "root":
+		root, err := r.root()
+		if err != nil {
+			return err
+		}
+		expires = root.Expires
+	case "snapshot":
+		snapshot, err := r.snapshot()
+		if err != nil {
+			return err
+		}
+		expires = snapshot.Expires
+	case "timestamp":
+		timestamp, err := r.timestamp()
+		if err != nil {
+			return err
+		}
+		expires = timestamp.Expires
+	case "targets":
+		targets, err := r.topLevelTargets()
+		if err != nil {
+			return err
+		}
+		expires = targets.Expires
+	default:
+		return fmt.Errorf("invalid role: %s", role)
+	}
+	if expires.Before(validAt) || expires.Equal(validAt) {
+		return fmt.Errorf("role expired on: %s", expires)
+	}
+	return nil
+}


### PR DESCRIPTION
This command can be used to help automation tooling decide when
metadata expirations will be reached.
```
 # See if timestamp metadata is expiring in the next hour:
 $ tuf status --valid-at "$(date -d '+1 hour')" timestamp
```
Signed-off-by: Andy Doan <andy@foundries.io>

Please fill in the fields below to submit a pull request.  The more information that is provided, the better.

Fixes #329
Release Notes: <!-- What comments/remarks should we include in the release notes for this change? -->

**Types of changes**:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [  ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [  ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Description of the changes being introduced by the pull request**:

**Please verify and check that the pull request fulfills the following requirements**:

- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature
