### PR TITLE
fix: Redirect passphrase output to Standard error

### DIFF
--- a/cmd/tuf/main.go
+++ b/cmd/tuf/main.go
@@ -145,9 +145,9 @@ func getPassphrase(role string, confirm bool, change bool) ([]byte, error) {
 		// No environment variable set, so proceed prompting for new passphrase
 		role = fmt.Sprintf("new %s", role)
 	}
-	fmt.Printf("Enter %s keys passphrase: ", role)
+	fmt.Fprintf(os.Stderr, "Enter %s keys passphrase: ", role)
 	passphrase, err := term.ReadPassword(int(syscall.Stdin))
-	fmt.Println()
+	fmt.Fprintln(os.Stderr)
 	if err != nil {
 		return nil, err
 	}
@@ -156,9 +156,9 @@ func getPassphrase(role string, confirm bool, change bool) ([]byte, error) {
 		return passphrase, nil
 	}
 
-	fmt.Printf("Repeat %s keys passphrase: ", role)
+	fmt.Fprintf(os.Stderr, "Repeat %s keys passphrase: ", role)
 	confirmation, err := term.ReadPassword(int(syscall.Stdin))
-	fmt.Println()
+	fmt.Fprintln(os.Stderr)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: Andrés Torres <andrest@vmware.com>

Please fill in the fields below to submit a pull request.  The more information that is provided, the better.

Fixes #<Issue>
Release Notes: <!-- What comments/remarks should we include in the release notes for this change? -->

**Types of changes**:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [  ] New feature (non-breaking change which adds functionality)
- [  ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Description of the changes being introduced by the pull request**:
Redirect passphrase output to Standard error so that we can pipe the output of commands requiring passphrases. See https://github.com/theupdateframework/go-tuf/pull/160#issuecomment-937711887 and https://cloud-native.slack.com/archives/C02D577GX54/p1657742840578189

**Please verify and check that the pull request fulfills the following requirements**:
No tests added as cmd/tuf/main.go has no tests. No docs needed.
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature
