### PR TITLE
fix: Remove typo in Alternate signing flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Enter root keys passphrase:
 Copy `root.json.sigs` back to the repo box and import the signatures:
 
 ``` bash
-$ tuf add-signatures --signatures=root.json.sigs root.json
+$ tuf add-signatures --signatures root.json.sigs root.json
 ```
 
 This achieves the same state as the above flow for the repo box:


### PR DESCRIPTION
Signed-off-by: Andrés Torres <andrest@vmware.com>

Please fill in the fields below to submit a pull request.  The more information that is provided, the better.

Fixes #<Issue>
Release Notes: <!-- What comments/remarks should we include in the release notes for this change? -->

**Types of changes**:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [  ] New feature (non-breaking change which adds functionality)
- [  ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Description of the changes being introduced by the pull request**:
Remove typo in _Alternate signing flow_ section of README. Running the current command was returning:
```
tuff add-signatures --signatures=root.json.sigs root.json
--signatures must not have an argument
```
With the suggestion, the command works as expected:
```
tuf add-signatures --signatures root.json.sigs root.json
tuf: added 1 new signature(s)
```
**Please verify and check that the pull request fulfills the following requirements**:

- [ ] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature
