### PR TITLE
fix: add leveldb recover ability

### DIFF
--- a/client/leveldbstore/leveldbstore.go
+++ b/client/leveldbstore/leveldbstore.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/errors"
 	"github.com/syndtr/goleveldb/leveldb/storage"
 
 	tuf_client "github.com/theupdateframework/go-tuf/client"
@@ -16,6 +17,10 @@ func FileLocalStore(path string) (tuf_client.LocalStore, error) {
 	}
 
 	db, err := leveldb.Open(fd, nil)
+	if err != nil && errors.IsCorrupted(err) {
+		db, err = leveldb.Recover(fd, nil)
+	}
+
 	return &fileLocalStore{fd: fd, db: db}, err
 }
 

--- a/client/leveldbstore/leveldbstore_test.go
+++ b/client/leveldbstore/leveldbstore_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	. "gopkg.in/check.v1"
+	"os"
 )
 
 type LocalStoreSuite struct{}
@@ -57,6 +58,45 @@ func (LocalStoreSuite) TestDeleteMeta(c *C) {
 	tmp := c.MkDir()
 	path := filepath.Join(tmp, "tuf.db")
 	store, err := FileLocalStore(path)
+	c.Assert(err, IsNil)
+
+	type meta map[string]json.RawMessage
+
+	assertGet := func(expected meta) {
+		actual, err := store.GetMeta()
+		c.Assert(err, IsNil)
+		c.Assert(meta(actual), DeepEquals, expected)
+	}
+
+	// initial GetMeta should return empty meta
+	assertGet(meta{})
+
+	// SetMeta should persist
+	rootJSON := []byte(`{"_type":"Root"}`)
+	c.Assert(store.SetMeta("root.json", rootJSON), IsNil)
+	assertGet(meta{"root.json": rootJSON})
+
+	store.DeleteMeta("root.json")
+	m, _ := store.GetMeta()
+	if _, ok := m["root.json"]; ok {
+		c.Fatalf("Metadata is not deleted!")
+	}
+}
+
+func (LocalStoreSuite) TestCorruptManifest(c *C) {
+	tmp := c.MkDir()
+	path := filepath.Join(tmp, "tuf.db")
+
+	store, err := FileLocalStore(path)
+	c.Assert(err, IsNil)
+
+	// now break the manifest file
+	err = os.Truncate(filepath.Join(path, "MANIFEST-000000"), 1)
+	c.Assert(err, IsNil)
+	err = store.Close()
+	c.Assert(err, IsNil)
+
+	store, err = FileLocalStore(path)
 	c.Assert(err, IsNil)
 
 	type meta map[string]json.RawMessage


### PR DESCRIPTION
While fixing #349, the leveldb supports a Recover() method in case the
manifest is broken. I validated that the Recover would have recovered
the manifest file using the db file (that still existed). Add a test
that validates if the manifest is truncated, it can be recovered.

Signed-off-by: Mike Marchetti <mike@agilicus.com>

Please fill in the fields below to submit a pull request.  The more information that is provided, the better.

Fixes #<Issue>
Release Notes: <!-- What comments/remarks should we include in the release notes for this change? -->

**Types of changes**:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [  ] New feature (non-breaking change which adds functionality)
- [  ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Description of the changes being introduced by the pull request**:

**Please verify and check that the pull request fulfills the following requirements**:

- [x] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature
