### PR TITLE
refactor!: rename "InitLocal" to "Init"

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -106,13 +106,13 @@ func NewClient(local LocalStore, remote RemoteStore) *Client {
 	}
 }
 
-// InitLocal initializes a local repository from root metadata.
+// Init initializes a local repository from root metadata.
 //
 // The root's keys are extracted from the root and saved in local storage.
 // Root expiration is not checked.
 // It is expected that rootJSON was securely distributed with the software
 // being updated.
-func (c *Client) InitLocal(rootJSON []byte) error {
+func (c *Client) Init(rootJSON []byte) error {
 	err := c.loadAndVerifyRootMeta(rootJSON, true /*ignoreExpiredCheck*/)
 	if err != nil {
 		return err

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -244,25 +244,6 @@ func (s *ClientSuite) assertErrExpired(c *C, err error, file string) {
 	c.Assert(expiredErr.Expired.Unix(), Equals, s.expiredTime.Round(time.Second).Unix())
 }
 
-func (s *ClientSuite) TestInit(c *C) {
-	client := NewClient(MemoryLocalStore(), s.remote)
-
-	// check invalid json
-	c.Assert(client.Init(make([]byte, 0)), NotNil)
-	rootJson := `{ "signatures": [], "signed": {"version": "wrongtype"}, "spec_version": "1.0.0", "version": 1}`
-	err := client.Init([]byte(rootJson))
-	c.Assert(err.Error(), Matches, "json: cannot unmarshal string.*")
-
-	// check Update() returns ErrNoRootKeys when uninitialized
-	_, err = client.Update()
-	c.Assert(err, Equals, ErrNoRootKeys)
-
-	// check Update() does not return ErrNoRootKeys after initialization
-	c.Assert(client.Init(s.rootMeta(c)), IsNil)
-	_, err = client.Update()
-	c.Assert(err, IsNil)
-}
-
 func (s *ClientSuite) TestInitAllowsExpired(c *C) {
 	s.genKeyExpired(c, "targets")
 	c.Assert(s.repo.Snapshot(), IsNil)

--- a/client/delegations_test.go
+++ b/client/delegations_test.go
@@ -275,7 +275,7 @@ func initTestDelegationClient(t *testing.T, dirPrefix string) (*Client, func() e
 	c := NewClient(MemoryLocalStore(), remote)
 	rawFile, err := ioutil.ReadFile(initialStateDir + "/" + "root.json")
 	assert.Nil(t, err)
-	assert.Nil(t, c.InitLocal(rawFile))
+	assert.Nil(t, c.Init(rawFile))
 	files, err := ioutil.ReadDir(initialStateDir)
 	assert.Nil(t, err)
 

--- a/client/interop_test.go
+++ b/client/interop_test.go
@@ -153,7 +153,7 @@ func (t *testCase) runStep(c *C, stepName string) {
 	c.Assert(err, IsNil)
 	rootJsonBytes, err := io.ReadAll(ioReader)
 	c.Assert(err, IsNil)
-	c.Assert(client.InitLocal(rootJsonBytes), IsNil)
+	c.Assert(client.Init(rootJsonBytes), IsNil)
 
 	// check update returns the correct updated targets
 	files, err := client.Update()

--- a/client/python_interop/python_interop_test.go
+++ b/client/python_interop/python_interop_test.go
@@ -59,7 +59,7 @@ func (InteropSuite) TestGoClientPythonGenerated(c *C) {
 		client := client.NewClient(client.MemoryLocalStore(), remote)
 		rootJSON, err := ioutil.ReadFile(filepath.Join(testDataDir, dir, "repository", "metadata", "root.json"))
 		c.Assert(err, IsNil)
-		c.Assert(client.InitLocal(rootJSON), IsNil)
+		c.Assert(client.Init(rootJSON), IsNil)
 
 		// check update returns the correct updated targets
 		files, err := client.Update()

--- a/cmd/tuf-client/init.go
+++ b/cmd/tuf-client/init.go
@@ -35,5 +35,5 @@ func cmdInit(args *docopt.Args, client *tuf.Client) error {
 	if err != nil {
 		return err
 	}
-	return client.InitLocal(bytes)
+	return client.Init(bytes)
 }


### PR DESCRIPTION
Straightforward find/replace:

    find . -name '*.go' | xargs sed -i 's/InitLocal/Init/g'

BREAKING CHANGE: the method signature of `Init()` has changed since the
last release to take in the raw `root.json` metadata.

Signed-off-by: Zachary Newman <z@znewman.net>

Please fill in the fields below to submit a pull request.  The more information that is provided, the better.

Fixes #208
Release Notes: the method signature of `Init()` has changed since the
last release to take in the raw `root.json` metadata.

**Types of changes**:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Description of the changes being introduced by the pull request**: rename "InitLocal" to "Init"

**Please verify and check that the pull request fulfills the following requirements**:

- [X] Tests have been added for the bug fix or new feature
- [X] Docs have been added for the bug fix or new feature
