### PR TITLE
build: Use Go 1.17 for golangci linting and update golangci/golangci-lint-action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,5 +63,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@537aa1903e5d359d0b27dbc19ddd22c5087f3fbc
         with:
-          version: v1.45.2
+          version: v1.49.0
           args: --timeout 3m

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,6 +59,8 @@ jobs:
     needs: get-go-versions
     steps:
       - uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
+        with:
+          go-version: ${{ matrix.go-version }}
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@537aa1903e5d359d0b27dbc19ddd22c5087f3fbc

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,9 @@
+run:
+  # Lint using Go 1.17, since some linters are disabled by default for Go 1.18
+  # until generics are supported.
+  # See https://github.com/golangci/golangci-lint/issues/2649
+  go: '1.17'
+
 linters:
   disable-all: true
   enable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,7 +11,5 @@ linters:
     - gofmt
     - govet
     - gosimple
-    - structcheck
-    - varcheck
     - unused
     - typecheck

--- a/client/client.go
+++ b/client/client.go
@@ -672,19 +672,6 @@ func (c *Client) downloadMetaFromTimestamp(name string, m data.TimestampFileMeta
 	return b, nil
 }
 
-// decodeRoot decodes and verifies root metadata.
-//
-//lint:ignore U1000 unused
-func (c *Client) decodeRoot(b json.RawMessage) error {
-	root := &data.Root{}
-	if err := c.db.Unmarshal(b, root, "root", c.rootVer); err != nil {
-		return ErrDecodeFailed{"root.json", err}
-	}
-	c.rootVer = root.Version
-	c.consistentSnapshot = root.ConsistentSnapshot
-	return nil
-}
-
 // decodeSnapshot decodes and verifies snapshot metadata, and returns the new
 // root and targets file meta.
 func (c *Client) decodeSnapshot(b json.RawMessage) (data.SnapshotFiles, error) {

--- a/client/client.go
+++ b/client/client.go
@@ -674,6 +674,7 @@ func (c *Client) downloadMetaFromTimestamp(name string, m data.TimestampFileMeta
 }
 
 // decodeRoot decodes and verifies root metadata.
+//lint:ignore U1000 unused
 func (c *Client) decodeRoot(b json.RawMessage) error {
 	root := &data.Root{}
 	if err := c.db.Unmarshal(b, root, "root", c.rootVer); err != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -778,38 +778,6 @@ func (c *Client) localMetaFromSnapshot(name string, m data.SnapshotFileMeta) (js
 	return b, err == nil
 }
 
-// hasTargetsMeta checks whether local metadata has the given snapshot meta
-//
-//lint:ignore U1000 unused
-func (c *Client) hasTargetsMeta(m data.SnapshotFileMeta) bool {
-	b, ok := c.localMeta["targets.json"]
-	if !ok {
-		return false
-	}
-	meta, err := util.GenerateSnapshotFileMeta(bytes.NewReader(b), m.Hashes.HashAlgorithms()...)
-	if err != nil {
-		return false
-	}
-	err = util.SnapshotFileMetaEqual(meta, m)
-	return err == nil
-}
-
-// hasSnapshotMeta checks whether local metadata has the given meta
-//
-//lint:ignore U1000 unused
-func (c *Client) hasMetaFromTimestamp(name string, m data.TimestampFileMeta) bool {
-	b, ok := c.localMeta[name]
-	if !ok {
-		return false
-	}
-	meta, err := util.GenerateTimestampFileMeta(bytes.NewReader(b), m.Hashes.HashAlgorithms()...)
-	if err != nil {
-		return false
-	}
-	err = util.TimestampFileMetaEqual(meta, m)
-	return err == nil
-}
-
 type Destination interface {
 	io.Writer
 	Delete() error

--- a/client/client.go
+++ b/client/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"io"
+	"io/ioutil"
 
 	"github.com/theupdateframework/go-tuf/data"
 	"github.com/theupdateframework/go-tuf/util"
@@ -550,7 +551,7 @@ func (c *Client) downloadMetaUnsafe(name string, maxMetaSize int64) ([]byte, err
 	// although the size has been checked above, use a LimitReader in case
 	// the reported size is inaccurate, or size is -1 which indicates an
 	// unknown length
-	return io.ReadAll(io.LimitReader(r, maxMetaSize))
+	return ioutil.ReadAll(io.LimitReader(r, maxMetaSize))
 }
 
 // remoteGetFunc is the type of function the download method uses to download
@@ -621,7 +622,7 @@ func (c *Client) downloadMeta(name string, version int64, m data.FileMeta) ([]by
 		stream = r
 	}
 
-	return io.ReadAll(stream)
+	return ioutil.ReadAll(stream)
 }
 
 func (c *Client) downloadMetaFromSnapshot(name string, m data.SnapshotFileMeta) ([]byte, error) {
@@ -673,6 +674,7 @@ func (c *Client) downloadMetaFromTimestamp(name string, m data.TimestampFileMeta
 }
 
 // decodeRoot decodes and verifies root metadata.
+//
 //lint:ignore U1000 unused
 func (c *Client) decodeRoot(b json.RawMessage) error {
 	root := &data.Root{}
@@ -791,6 +793,7 @@ func (c *Client) localMetaFromSnapshot(name string, m data.SnapshotFileMeta) (js
 }
 
 // hasTargetsMeta checks whether local metadata has the given snapshot meta
+//
 //lint:ignore U1000 unused
 func (c *Client) hasTargetsMeta(m data.SnapshotFileMeta) bool {
 	b, ok := c.localMeta["targets.json"]
@@ -806,6 +809,7 @@ func (c *Client) hasTargetsMeta(m data.SnapshotFileMeta) bool {
 }
 
 // hasSnapshotMeta checks whether local metadata has the given meta
+//
 //lint:ignore U1000 unused
 func (c *Client) hasMetaFromTimestamp(name string, m data.TimestampFileMeta) bool {
 	b, ok := c.localMeta[name]
@@ -829,11 +833,11 @@ type Destination interface {
 //
 // dest will be deleted and an error returned in the following situations:
 //
-//   * The target does not exist in the local targets.json
-//   * Failed to fetch the chain of delegations accessible from local snapshot.json
-//   * The target does not exist in any targets
-//   * Metadata cannot be generated for the downloaded data
-//   * Generated metadata does not match local metadata for the given file
+//   - The target does not exist in the local targets.json
+//   - Failed to fetch the chain of delegations accessible from local snapshot.json
+//   - The target does not exist in any targets
+//   - Metadata cannot be generated for the downloaded data
+//   - Generated metadata does not match local metadata for the given file
 func (c *Client) Download(name string, dest Destination) (err error) {
 	// delete dest if there is an error
 	defer func() {

--- a/client/client.go
+++ b/client/client.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 
 	"github.com/theupdateframework/go-tuf/data"
 	"github.com/theupdateframework/go-tuf/util"
@@ -551,7 +550,7 @@ func (c *Client) downloadMetaUnsafe(name string, maxMetaSize int64) ([]byte, err
 	// although the size has been checked above, use a LimitReader in case
 	// the reported size is inaccurate, or size is -1 which indicates an
 	// unknown length
-	return ioutil.ReadAll(io.LimitReader(r, maxMetaSize))
+	return io.ReadAll(io.LimitReader(r, maxMetaSize))
 }
 
 // remoteGetFunc is the type of function the download method uses to download
@@ -622,7 +621,7 @@ func (c *Client) downloadMeta(name string, version int64, m data.FileMeta) ([]by
 		stream = r
 	}
 
-	return ioutil.ReadAll(stream)
+	return io.ReadAll(stream)
 }
 
 func (c *Client) downloadMetaFromSnapshot(name string, m data.SnapshotFileMeta) ([]byte, error) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -400,7 +399,7 @@ func newClientWithMeta(baseDir string, relPath string, serverAddr string) (*Clie
 	c := NewClient(MemoryLocalStore(), remote)
 	for _, m := range []string{"root.json", "snapshot.json", "timestamp.json", "targets.json"} {
 		if _, err := os.Stat(initialStateDir + "/" + m); err == nil {
-			metadataJSON, err := ioutil.ReadFile(initialStateDir + "/" + m)
+			metadataJSON, err := os.ReadFile(initialStateDir + "/" + m)
 			if err != nil {
 				return nil, err
 			}
@@ -1213,7 +1212,7 @@ func generateRepoFS(c *C, dir string, files map[string][]byte, consistentSnapsho
 	for file, data := range files {
 		path := filepath.Join(dir, "staged", "targets", file)
 		c.Assert(os.MkdirAll(filepath.Dir(path), 0755), IsNil)
-		c.Assert(ioutil.WriteFile(path, data, 0644), IsNil)
+		c.Assert(os.WriteFile(path, data, 0644), IsNil)
 		c.Assert(repo.AddTarget(file, nil), IsNil)
 	}
 	c.Assert(repo.Snapshot(), IsNil)

--- a/client/delegations_test.go
+++ b/client/delegations_test.go
@@ -5,9 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -273,10 +273,10 @@ func initTestDelegationClient(t *testing.T, dirPrefix string) (*Client, func() e
 	assert.Nil(t, err)
 
 	c := NewClient(MemoryLocalStore(), remote)
-	rawFile, err := ioutil.ReadFile(initialStateDir + "/" + "root.json")
+	rawFile, err := os.ReadFile(initialStateDir + "/" + "root.json")
 	assert.Nil(t, err)
 	assert.Nil(t, c.Init(rawFile))
-	files, err := ioutil.ReadDir(initialStateDir)
+	files, err := os.ReadDir(initialStateDir)
 	assert.Nil(t, err)
 
 	// load local files
@@ -287,7 +287,7 @@ func initTestDelegationClient(t *testing.T, dirPrefix string) (*Client, func() e
 		name := f.Name()
 		// ignoring consistent snapshot when loading initial state
 		if len(strings.Split(name, ".")) == 1 && strings.HasSuffix(name, ".json") {
-			rawFile, err := ioutil.ReadFile(initialStateDir + "/" + name)
+			rawFile, err := os.ReadFile(initialStateDir + "/" + name)
 			assert.Nil(t, err)
 			assert.Nil(t, c.local.SetMeta(name, rawFile))
 		}

--- a/client/interop_test.go
+++ b/client/interop_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -33,7 +32,7 @@ func checkGoIdentity(c *C, consistentSnapshot bool) {
 	c.Assert(err, IsNil)
 	testDataDir := filepath.Join(cwd, "testdata")
 
-	tempDir, err := ioutil.TempDir("", "")
+	tempDir, err := os.MkdirTemp("", "")
 	c.Assert(err, IsNil)
 	defer os.RemoveAll(tempDir)
 
@@ -59,7 +58,7 @@ func computeHashes(c *C, dir string) map[string]string {
 			return nil
 		}
 
-		bytes, err := ioutil.ReadFile(path)
+		bytes, err := os.ReadFile(path)
 		if err != nil {
 			return err
 		}
@@ -108,7 +107,7 @@ func newTestCase(c *C, name string, consistentSnapshot bool, options *HTTPRemote
 	c.Assert(err, IsNil)
 	testDir := filepath.Join(cwd, "testdata", name, fmt.Sprintf("consistent-snapshot-%t", consistentSnapshot))
 
-	dirEntries, err := ioutil.ReadDir(testDir)
+	dirEntries, err := os.ReadDir(testDir)
 	c.Assert(err, IsNil)
 	c.Assert(dirEntries, Not(HasLen), 0)
 

--- a/client/python_interop/python_interop_test.go
+++ b/client/python_interop/python_interop_test.go
@@ -3,7 +3,6 @@ package client
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -58,7 +57,7 @@ func (InteropSuite) TestGoClientPythonGenerated(c *C) {
 
 		// initiate a client with the root metadata
 		client := client.NewClient(client.MemoryLocalStore(), remote)
-		rootJSON, err := ioutil.ReadFile(filepath.Join(testDataDir, dir, "repository", "metadata", "1.root.json"))
+		rootJSON, err := os.ReadFile(filepath.Join(testDataDir, dir, "repository", "metadata", "1.root.json"))
 		c.Assert(err, IsNil)
 		c.Assert(client.Init(rootJSON), IsNil)
 
@@ -99,7 +98,7 @@ func generateRepoFS(c *C, dir string, files map[string][]byte, consistentSnapsho
 	for file, data := range files {
 		path := filepath.Join(dir, "staged", "targets", file)
 		c.Assert(os.MkdirAll(filepath.Dir(path), 0755), IsNil)
-		c.Assert(ioutil.WriteFile(path, data, 0644), IsNil)
+		c.Assert(os.WriteFile(path, data, 0644), IsNil)
 		c.Assert(repo.AddTarget(file, nil), IsNil)
 	}
 	c.Assert(repo.Snapshot(), IsNil)
@@ -134,9 +133,9 @@ func (InteropSuite) TestPythonClientGoGenerated(c *C) {
 		prevDir := filepath.Join(clientDir, "tufrepo", "metadata", "previous")
 		c.Assert(os.MkdirAll(currDir, 0755), IsNil)
 		c.Assert(os.MkdirAll(prevDir, 0755), IsNil)
-		rootJSON, err := ioutil.ReadFile(filepath.Join(dir, "repository", "1.root.json"))
+		rootJSON, err := os.ReadFile(filepath.Join(dir, "repository", "1.root.json"))
 		c.Assert(err, IsNil)
-		c.Assert(ioutil.WriteFile(filepath.Join(currDir, "root.json"), rootJSON, 0644), IsNil)
+		c.Assert(os.WriteFile(filepath.Join(currDir, "root.json"), rootJSON, 0644), IsNil)
 
 		args := []string{
 			filepath.Join(cwd, "testdata", "python-tuf-v1.0.0", "client.py"),
@@ -155,7 +154,7 @@ func (InteropSuite) TestPythonClientGoGenerated(c *C) {
 
 		// check the target files got downloaded
 		for path, expected := range files {
-			actual, err := ioutil.ReadFile(filepath.Join(clientDir, "tuftargets", url.QueryEscape(path)))
+			actual, err := os.ReadFile(filepath.Join(clientDir, "tuftargets", url.QueryEscape(path)))
 			c.Assert(err, IsNil)
 			c.Assert(actual, DeepEquals, expected)
 		}

--- a/client/testdata/go-tuf-transition-M3/generate.go
+++ b/client/testdata/go-tuf-transition-M3/generate.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -64,7 +63,7 @@ func addTargets(repo *tuf.Repo, dir string, files map[string][]byte) {
 	for file, data := range files {
 		path := filepath.Join(dir, "staged", "targets", file)
 		assertNoError(os.MkdirAll(filepath.Dir(path), 0755))
-		assertNoError(ioutil.WriteFile(path, data, 0644))
+		assertNoError(os.WriteFile(path, data, 0644))
 		paths = append(paths, file)
 	}
 	assertNoError(repo.AddTargetsWithExpires(paths, nil, expirationDate))

--- a/client/testdata/go-tuf-transition-M4/generate.go
+++ b/client/testdata/go-tuf-transition-M4/generate.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -62,7 +61,7 @@ func addTargets(repo *tuf.Repo, dir string, files map[string][]byte) {
 	for file, data := range files {
 		path := filepath.Join(dir, "staged", "targets", file)
 		assertNoError(os.MkdirAll(filepath.Dir(path), 0755))
-		assertNoError(ioutil.WriteFile(path, data, 0644))
+		assertNoError(os.WriteFile(path, data, 0644))
 		paths = append(paths, file)
 	}
 	assertNoError(repo.AddTargetsWithExpires(paths, nil, expirationDate))

--- a/client/testdata/go-tuf/generator/generator.go
+++ b/client/testdata/go-tuf/generator/generator.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -97,7 +96,7 @@ func addTargets(repo *tuf.Repo, dir string, files map[string][]byte) {
 	for file, data := range files {
 		path := filepath.Join(dir, "staged", "targets", file)
 		assertNoError(os.MkdirAll(filepath.Dir(path), 0755))
-		assertNoError(ioutil.WriteFile(path, data, 0644))
+		assertNoError(os.WriteFile(path, data, 0644))
 		paths = append(paths, file)
 	}
 	assertNoError(repo.AddTargetsWithExpires(paths, nil, expirationDate))

--- a/client/testdata/tools/gen-keys.go
+++ b/client/testdata/tools/gen-keys.go
@@ -7,7 +7,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/theupdateframework/go-tuf/data"
@@ -40,7 +40,7 @@ func main() {
 	s, err := json.MarshalIndent(&roles, "", "    ")
 	assertNoError(err)
 
-	ioutil.WriteFile("keys.json", []byte(s), 0644)
+	os.WriteFile("keys.json", []byte(s), 0644)
 }
 
 func assertNoError(err error) {

--- a/client/testdata/tools/linkify-metadata.go
+++ b/client/testdata/tools/linkify-metadata.go
@@ -7,7 +7,6 @@ package main
 import (
 	"crypto/sha256"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -55,7 +54,7 @@ func linkifyDir(rootDir string) error {
 }
 
 func readStepDirs(rootDir string) ([]string, error) {
-	dirEntries, err := ioutil.ReadDir(rootDir)
+	dirEntries, err := os.ReadDir(rootDir)
 	if err != nil {
 		return []string{}, err
 	}
@@ -79,7 +78,7 @@ func computeHashes(dir string) map[string][32]byte {
 			return nil
 		}
 
-		bytes, err := ioutil.ReadFile(path)
+		bytes, err := os.ReadFile(path)
 		if err != nil {
 			return err
 		}

--- a/cmd/tuf-client/get.go
+++ b/cmd/tuf-client/get.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/flynn/go-docopt"
@@ -35,7 +34,7 @@ func cmdGet(args *docopt.Args, client *tuf.Client) error {
 		return err
 	}
 	target := util.NormalizeTarget(args.String["<target>"])
-	file, err := ioutil.TempFile("", "go-tuf")
+	file, err := os.CreateTemp("", "go-tuf")
 	if err != nil {
 		return err
 	}

--- a/local_store.go
+++ b/local_store.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -276,7 +275,7 @@ func (f *fileSystemStore) GetMeta() (map[string]json.RawMessage, error) {
 
 	meta := make(map[string]json.RawMessage)
 	for name, path := range metaPaths {
-		f, err := ioutil.ReadFile(path)
+		f, err := os.ReadFile(path)
 		if err != nil {
 			return nil, err
 		}

--- a/repo_test.go
+++ b/repo_test.go
@@ -2684,7 +2684,7 @@ func (rs *RepoSuite) TestTargetMetadataLength(c *C) {
 	}
 	s := &data.Signed{}
 	c.Assert(json.Unmarshal(targetsJSON, s), IsNil)
-	fmt.Fprintf(os.Stderr, string(s.Signed))
+	fmt.Fprint(os.Stderr, s.Signed)
 	var objMap map[string]json.RawMessage
 	c.Assert(json.Unmarshal(s.Signed, &objMap), IsNil)
 	targetsMap, ok := objMap["targets"]
@@ -2697,8 +2697,11 @@ func (rs *RepoSuite) TestTargetMetadataLength(c *C) {
 		c.Fatal("missing foo.txt in targets")
 	}
 	c.Assert(json.Unmarshal(targetsMap, &objMap), IsNil)
-	targetsMap, ok = objMap["length"]
+	lengthMsg, ok := objMap["length"]
 	if !ok {
 		c.Fatal("missing length field in foo.txt file meta")
 	}
+	var length int64
+	c.Assert(json.Unmarshal(lengthMsg, &length), IsNil)
+	c.Assert(length, Equals, int64(0))
 }

--- a/repo_test.go
+++ b/repo_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -907,7 +906,8 @@ func (t *tmpDir) assertEmpty(dir string) {
 	}
 	t.c.Assert(err, IsNil)
 	t.c.Assert(f.IsDir(), Equals, true)
-	entries, err := ioutil.ReadDir(path)
+
+	entries, err := os.ReadDir(path)
 	t.c.Assert(err, IsNil)
 	// check that all (if any) entries are also empty
 	for _, e := range entries {
@@ -927,12 +927,12 @@ func (t *tmpDir) stagedTargetPath(path string) string {
 func (t *tmpDir) writeStagedTarget(path, data string) {
 	path = t.stagedTargetPath(path)
 	t.c.Assert(os.MkdirAll(filepath.Dir(path), 0755), IsNil)
-	t.c.Assert(ioutil.WriteFile(path, []byte(data), 0644), IsNil)
+	t.c.Assert(os.WriteFile(path, []byte(data), 0644), IsNil)
 }
 
 func (t *tmpDir) readFile(path string) []byte {
 	t.assertExists(path)
-	data, err := ioutil.ReadFile(filepath.Join(t.path, path))
+	data, err := os.ReadFile(filepath.Join(t.path, path))
 	t.c.Assert(err, IsNil)
 	return data
 }

--- a/util/util.go
+++ b/util/util.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"hash"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -202,7 +201,7 @@ func GenerateFileMeta(r io.Reader, hashAlgorithms ...string) (data.FileMeta, err
 		hashes[hashAlgorithm] = h
 		r = io.TeeReader(r, h)
 	}
-	n, err := io.Copy(ioutil.Discard, r)
+	n, err := io.Copy(io.Discard, r)
 	if err != nil {
 		return data.FileMeta{}, err
 	}
@@ -218,7 +217,7 @@ type versionedMeta struct {
 }
 
 func generateVersionedFileMeta(r io.Reader, hashAlgorithms ...string) (data.FileMeta, int64, error) {
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		return data.FileMeta{}, 0, err
 	}
@@ -301,7 +300,7 @@ func HashedPaths(p string, hashes data.Hashes) []string {
 
 func AtomicallyWriteFile(filename string, data []byte, perm os.FileMode) error {
 	dir, name := filepath.Split(filename)
-	f, err := ioutil.TempFile(dir, name)
+	f, err := os.CreateTemp(dir, name)
 	if err != nil {
 		return err
 	}

--- a/verify/db_test.go
+++ b/verify/db_test.go
@@ -93,7 +93,6 @@ func TestDelegationsDB(t *testing.T) {
 // Previously, every key's key ID was the SHA256 of the public key. TAP-12
 // allows arbitrary key IDs, with no loss in security.
 //
-//
 // TAP-12: https://github.com/theupdateframework/taps/blob/master/tap12.md
 func TestTAP12(t *testing.T) {
 	db := NewDB()


### PR DESCRIPTION
Fixes #362
Release Notes:
- Use Go 1.17 for golangci linting until generics are supported.
- Update golangci/golangci-lint-action and run checks using the correct version of Go for the Go version matrix.

**Types of changes**:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Description of the changes being introduced by the pull request**:
Go 1.18 is not supported by golangci-lint yet since generics are not supported. To fix, we have to lint using Go 1.17. Note that gofmt checks still appear to target the latest Go version.

**Please verify and check that the pull request fulfills the following requirements**:

- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature
