### PR TITLE
fix(verify):  Fix a vulnerability in the verification of threshold signatures (due to handling of keys with multiple IDs)

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1348,7 +1348,7 @@ func (s *StateLessSuite) TestRejectsMultiSignaturesSameKeyDifferentIDs(c *C) {
 
 	err = client.UpdateRoots()
 	if err != nil {
-		c.Assert(err, DeepEquals, &verify.ErrRoleThreshold{Expected: 2, Actual: 1})
+		c.Assert(err, DeepEquals, verify.ErrRoleThreshold{Expected: 2, Actual: 1})
 	} else {
 		c.Fatalf("client returned no error when updating with evil root")
 	}

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -92,8 +92,8 @@ func (db *DB) VerifySignatures(s *data.Signed, role string) error {
 	// Verify that a threshold of keys signed the data. Since keys can have
 	// multiple key ids, we need to protect against multiple attached
 	// signatures that just differ on the key id.
-	seenKeys := make(map[string]struct{})
-	valid := 0
+	verifiedKeyIDs := make(map[string]struct{})
+	numVerifiedKeys := 0
 	for _, sig := range s.Signatures {
 		if !roleData.ValidKey(sig.KeyID) {
 			continue
@@ -104,6 +104,7 @@ func (db *DB) VerifySignatures(s *data.Signed, role string) error {
 		}
 
 		if err := verifier.Verify(msg, sig.Signature); err != nil {
+			// FIXME: don't err out on the 1st bad signature.
 			return ErrInvalid
 		}
 
@@ -115,20 +116,20 @@ func (db *DB) VerifySignatures(s *data.Signed, role string) error {
 		keyIDs := verifier.MarshalPublicKey().IDs()
 		wasKeySeen := false
 		for _, keyID := range keyIDs {
-			if _, present := seenKeys[keyID]; present {
+			if _, present := verifiedKeyIDs[keyID]; present {
 				wasKeySeen = true
 			}
 		}
 		if !wasKeySeen {
 			for _, id := range keyIDs {
-				seenKeys[id] = struct{}{}
+				verifiedKeyIDs[id] = struct{}{}
 			}
 
-			valid++
+			numVerifiedKeys++
 		}
 	}
-	if valid < roleData.Threshold {
-		return ErrRoleThreshold{roleData.Threshold, valid}
+	if numVerifiedKeys < roleData.Threshold {
+		return ErrRoleThreshold{roleData.Threshold, numVerifiedKeys}
 	}
 
 	return nil

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -92,7 +92,7 @@ func (db *DB) VerifySignatures(s *data.Signed, role string) error {
 	// Verify that a threshold of keys signed the data. Since keys can have
 	// multiple key ids, we need to protect against multiple attached
 	// signatures that just differ on the key id.
-	seen := make(map[string]struct{})
+	seenKeys := make(map[string]struct{})
 	valid := 0
 	for _, sig := range s.Signatures {
 		if !roleData.ValidKey(sig.KeyID) {
@@ -109,9 +109,19 @@ func (db *DB) VerifySignatures(s *data.Signed, role string) error {
 
 		// Only consider this key valid if we haven't seen any of it's
 		// key ids before.
-		if _, ok := seen[sig.KeyID]; !ok {
-			for _, id := range verifier.MarshalPublicKey().IDs() {
-				seen[id] = struct{}{}
+		// Careful: we must not rely on the key IDs _declared in the file_,
+		// instead we get to decide what key IDs this key correspond to.
+		// XXX dangerous; better stop supporting multiple key IDs altogether.
+		keyIDs := verifier.MarshalPublicKey().IDs()
+		wasKeySeen := false
+		for _, keyID := range keyIDs {
+			if _, present := seenKeys[keyID]; present {
+				wasKeySeen = true
+			}
+		}
+		if !wasKeySeen {
+			for _, id := range keyIDs {
+				seenKeys[id] = struct{}{}
 			}
 
 			valid++


### PR DESCRIPTION
Release Notes: Fixes a vulnerability in the verification of threshold signatures (due to handling of keys with multiple IDs)

**Types of changes**:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Description of the changes being introduced by the pull request**:


Go-TUF has a security vulnerability in the way it validates threshold signatures: it relies on the key IDs declared in the metadata file it is currently validating (varibale `sig.KeyID`) to tell if this new signature should count towards the threshold, assuming that these IDs will be the same as the one it generates (`verifier.MarshalPublicKey().IDs()`). This assumption can be made false and this can be leveraged to forge valid threshold signatures using a number of keys which, in theory, should be insufficient.

This PR adds a test demonstrating the vulnerability, then it fixes the vulnerability.

My opinion however is that Go-TUF should stop trying to be compatible with [old versions of TUF implementations that were assigning several IDs to a same key](https://github.com/theupdateframework/go-tuf/blob/8e84384bebe3b215a8f28f734f8227f71f737c6c/data/types.go#L50-L70), as this makes signature validation way too error-prone. Note that all versions of the TUF specification since version 1 are very clear on there being a single correct way to compute the key ID: 

> KEYID: The identifier of the key signing the ROLE object, which is a hexdigest of the SHA-256 hash of the canonical form of the key. The keyid MUST be unique in the "signatures" array: multiple signatures with the same keyid are not allowed.
>
> source: https://theupdateframework.github.io/specification/v1.0.29/index.html#role-keyid

> KEYID: A KEYID, which MUST be correct for the specified KEY. Clients MUST calculate each KEYID to verify this is correct for the associated key. Clients MUST ensure that for any KEYID represented in this key list and in other files, only one unique key has that KEYID.
>
> source: https://theupdateframework.github.io/specification/v1.0.29/index.html#root-keyid

Also, I am aware that [TAP 12](https://github.com/theupdateframework/taps/blob/master/tap12.md) (which does not apply to TUF 1.0.x anyway) introduces key ID flexibility. A better solution than the one in this PR would be to apply the recommendation in TAP 12 to _"use a standardized representation for keys, like the modulus and exponent for RSA or the point and curve for ECC"_. That's probably something we should do in Go-TUF without waiting for TUF 1.1.

**Please verify and check that the pull request fulfills the following requirements**:

- [x] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature
