### PR TITLE
add back SnapshotFileMeta.Custom

### DIFF
--- a/data/types.go
+++ b/data/types.go
@@ -161,9 +161,10 @@ func (f Hashes) HashAlgorithms() []string {
 }
 
 type metapathFileMeta struct {
-	Length  int64  `json:"length,omitempty"`
-	Hashes  Hashes `json:"hashes,omitempty"`
-	Version int64  `json:"version"`
+	Length  int64            `json:"length,omitempty"`
+	Hashes  Hashes           `json:"hashes,omitempty"`
+	Version int64            `json:"version"`
+	Custom  *json.RawMessage `json:"custom,omitempty"`
 }
 
 type SnapshotFileMeta metapathFileMeta


### PR DESCRIPTION
Adds back a `Custom` field to `SnapshotFileMeta` following its removal in https://github.com/theupdateframework/go-tuf/pull/345.

Release Notes: Add back a `Custom` field to `SnapshotFileMeta`

**Types of changes**:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Description of the changes being introduced by the pull request**:

We rely on this `Custom` field to store some custom data related to delegated `targets`. The removal of this field would force us to store this outside of the signed TUF file or in a hacky map in `Snapshot.Custom`.

**Please verify and check that the pull request fulfills the following requirements**:

- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature
