### PR TITLE
fix: fix is top level calculation for versioned manifests

### DIFF
--- a/internal/roles/roles.go
+++ b/internal/roles/roles.go
@@ -22,6 +22,9 @@ func IsDelegatedTargetsRole(name string) bool {
 }
 
 func IsTopLevelManifest(name string) bool {
+	if IsVersionedManifest(name) {
+		name = strings.Join(strings.Split(name, ".")[1:], ".")
+	}
 	return IsTopLevelRole(strings.TrimSuffix(name, ".json"))
 }
 

--- a/internal/roles/roles_test.go
+++ b/internal/roles/roles_test.go
@@ -24,18 +24,24 @@ func TestIsDelegatedTargetsRole(t *testing.T) {
 
 func TestIsTopLevelManifest(t *testing.T) {
 	assert.True(t, IsTopLevelManifest("root.json"))
+	assert.True(t, IsTopLevelManifest("1.root.json"))
 	assert.True(t, IsTopLevelManifest("targets.json"))
 	assert.True(t, IsTopLevelManifest("timestamp.json"))
 	assert.True(t, IsTopLevelManifest("snapshot.json"))
+	assert.True(t, IsTopLevelManifest("2.snapshot.json"))
 	assert.False(t, IsTopLevelManifest("bins.json"))
+	assert.False(t, IsTopLevelManifest("3.bins.json"))
 }
 
 func TestIsDelegatedTargetsManifest(t *testing.T) {
 	assert.False(t, IsDelegatedTargetsManifest("root.json"))
+	assert.False(t, IsDelegatedTargetsManifest("1.root.json"))
 	assert.False(t, IsDelegatedTargetsManifest("targets.json"))
+	assert.False(t, IsDelegatedTargetsManifest("2.targets.json"))
 	assert.False(t, IsDelegatedTargetsManifest("timestamp.json"))
 	assert.False(t, IsDelegatedTargetsManifest("snapshot.json"))
 	assert.True(t, IsDelegatedTargetsManifest("bins.json"))
+	assert.True(t, IsDelegatedTargetsManifest("2.bins.json"))
 }
 
 func TestIsVersionedManifest(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Please fill in the fields below to submit a pull request.  The more information that is provided, the better.

Fixes https://github.com/theupdateframework/go-tuf/issues/380
Release Notes: <!-- What comments/remarks should we include in the release notes for this change? -->
* fix: fixes bug in calculation of top-level manifest for versioned manifests

**Types of changes**:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Description of the changes being introduced by the pull request**:
Fixes the calculation of whether a manifest is a top-level one when the manifest is versioned. Previously, a manifest like 1.root.json would be detected as a delegated manifest because it was 1.root was not in the set of top-level manifests. This now accounts for versioned manifests.

**Please verify and check that the pull request fulfills the following requirements**:

- [ x ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature
