### PR TITLE
test: update lint CI parameters

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,5 +65,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@537aa1903e5d359d0b27dbc19ddd22c5087f3fbc
         with:
-          version: v1.49.0
-          args: --timeout 3m
+          version: v1.49
+          args: --timeout 5m --verbose


### PR DESCRIPTION
Signed-off-by: Zachary Newman <z@znewman.net>

Context: linting in CI (`golangci-lint`) occasionally times out on
Windows (flaky). Most of the time, it's fast enough (~1min). But
occasionally it hits the 3 minute timeout. It's somewhat expected that
`golangci-lint` is slow:

https://github.com/golangci/golangci-lint-action/issues/297

This PR does 3 things:

1. Bump the timeout from 3 to 5 minutes (why solve the problem when you
   can band-aid it?)
2. Add the `--verbose` flag, so if we start to see this again we'll have
   much better information with which to figure out what specifically is
   taking so long.
3. Remove the patch number from the `golangci-lint` version; it's
   disallowed, according to the `golangci-lint` action README.

Fixes https://github.com/theupdateframework/go-tuf/issues/390 (for now).