### PR TITLE
test: Do not fail-fast when CI runs.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,7 @@ jobs:
 
   run:
     strategy:
+      fail-fast: false # Keep running if one leg fails.
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         go-version: ${{ fromJSON(needs.get-go-versions.outputs.matrix) }}


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

Fixes #<Issue>
Release Notes: <!-- What comments/remarks should we include in the release notes for this change? -->

**Types of changes**:
Currently if a single test leg fails all the legs are immediately failed. This makes testing a bit cumbersome because it would be better to see all the failures at once rather than whack a mole. This is especially troublesome when the tests run on a machine that I do not have access to in order test that platform.

**Description of the changes being introduced by the pull request**:

**Please verify and check that the pull request fulfills the following requirements**:

- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature
