### PR TITLE
fix: fix delegation null json value interoperability

### DIFF
--- a/client/python_interop/python_interop_test.go
+++ b/client/python_interop/python_interop_test.go
@@ -85,7 +85,8 @@ func (InteropSuite) TestGoClientPythonGenerated(c *C) {
 	}
 }
 
-func generateRepoFS(c *C, dir string, files map[string][]byte, consistentSnapshot bool) *tuf.Repo {
+func generateRepoFS(c *C, dir string, files map[string][]byte,
+	consistentSnapshot bool) *tuf.Repo {
 	repo, err := tuf.NewRepo(tuf.FileSystemStore(dir, nil))
 	c.Assert(err, IsNil)
 	if !consistentSnapshot {
@@ -107,6 +108,12 @@ func generateRepoFS(c *C, dir string, files map[string][]byte, consistentSnapsho
 	return repo
 }
 
+func refreshRepo(c *C, repo *tuf.Repo) {
+	c.Assert(repo.Snapshot(), IsNil)
+	c.Assert(repo.Timestamp(), IsNil)
+	c.Assert(repo.Commit(), IsNil)
+}
+
 func (InteropSuite) TestPythonClientGoGenerated(c *C) {
 	// clone the Python client if necessary
 	cwd, err := os.Getwd()
@@ -126,6 +133,65 @@ func (InteropSuite) TestPythonClientGoGenerated(c *C) {
 		name := fmt.Sprintf("consistent-snapshot-%t", consistentSnapshot)
 		dir := filepath.Join(tmp, name)
 		generateRepoFS(c, dir, files, consistentSnapshot)
+
+		// create initial files for Python client
+		clientDir := filepath.Join(dir, "client")
+		currDir := filepath.Join(clientDir, "tufrepo", "metadata", "current")
+		prevDir := filepath.Join(clientDir, "tufrepo", "metadata", "previous")
+		c.Assert(os.MkdirAll(currDir, 0755), IsNil)
+		c.Assert(os.MkdirAll(prevDir, 0755), IsNil)
+		rootJSON, err := os.ReadFile(filepath.Join(dir, "repository", "1.root.json"))
+		c.Assert(err, IsNil)
+		c.Assert(os.WriteFile(filepath.Join(currDir, "root.json"), rootJSON, 0644), IsNil)
+
+		args := []string{
+			filepath.Join(cwd, "testdata", "python-tuf-v1.0.0", "client.py"),
+			"--repo=http://" + addr + "/" + name,
+		}
+		for path := range files {
+			args = append(args, path)
+		}
+
+		// run Python client update
+		cmd := exec.Command("python", args...)
+		cmd.Dir = clientDir
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		c.Assert(cmd.Run(), IsNil)
+
+		// check the target files got downloaded
+		for path, expected := range files {
+			actual, err := os.ReadFile(filepath.Join(clientDir, "tuftargets", url.QueryEscape(path)))
+			c.Assert(err, IsNil)
+			c.Assert(actual, DeepEquals, expected)
+		}
+	}
+}
+
+// This is a regression test for issue
+// https://github.com/theupdateframework/go-tuf/issues/402
+func (InteropSuite) TestPythonClientGoGeneratedNullDelegations(c *C) {
+	// clone the Python client if necessary
+	cwd, err := os.Getwd()
+	c.Assert(err, IsNil)
+
+	files := map[string][]byte{
+		"foo.txt":     []byte("foo"),
+		"bar/baz.txt": []byte("baz"),
+	}
+
+	for _, consistentSnapshot := range []bool{false, true} {
+		// generate repository
+		tmp := c.MkDir()
+		// start file server
+		addr, cleanup := startFileServer(c, tmp)
+		defer cleanup()
+		name := fmt.Sprintf("consistent-snapshot-delegations-%t", consistentSnapshot)
+		dir := filepath.Join(tmp, name)
+		repo := generateRepoFS(c, dir, files, consistentSnapshot)
+		// "Reset" top-level targets delegations and re-sign
+		c.Assert(repo.ResetTargetsDelegations("targets"), IsNil)
+		refreshRepo(c, repo)
 
 		// create initial files for Python client
 		clientDir := filepath.Join(dir, "client")

--- a/repo.go
+++ b/repo.go
@@ -698,8 +698,7 @@ func (r *Repo) ResetTargetsDelegationsWithExpires(delegator string, expires time
 		return fmt.Errorf("error getting delegator (%q) metadata: %w", delegator, err)
 	}
 
-	t.Delegations = &data.Delegations{}
-	t.Delegations.Keys = make(map[string]*data.PublicKey)
+	t.Delegations = nil
 
 	t.Expires = expires.Round(time.Second)
 

--- a/repo_test.go
+++ b/repo_test.go
@@ -2044,6 +2044,14 @@ func (rs *RepoSuite) TestDelegations(c *C) {
 		t, err := r.targets(delegator)
 		c.Assert(err, IsNil)
 
+		// Check if there are no delegations.
+		if t.Delegations == nil {
+			if delegatedRoles != nil {
+				c.Fatal("expected delegated roles on delegator")
+			}
+			return
+		}
+
 		// Check that delegated roles are copied verbatim.
 		c.Assert(t.Delegations.Roles, DeepEquals, delegatedRoles)
 


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

When reseting a targets delegations, the `roles` are set to a `null` JSON value. Instead, remove the entire `delegations` field.

Added a test in the python client interoperability test


Please fill in the fields below to submit a pull request.  The more information that is provided, the better.

Fixes #<Issue>
Release Notes: <!-- What comments/remarks should we include in the release notes for this change? -->

**Types of changes**:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Description of the changes being introduced by the pull request**:

**Please verify and check that the pull request fulfills the following requirements**:

- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature
