### PR TITLE
fix(data): initialise new root/targets metadata at v1 instead of v0

### DIFF
--- a/data/types.go
+++ b/data/types.go
@@ -124,6 +124,7 @@ func NewRoot() *Root {
 		Expires:            DefaultExpires("root"),
 		Keys:               make(map[string]*PublicKey),
 		Roles:              make(map[string]*Role),
+		Version:            1,
 		ConsistentSnapshot: true,
 	}
 }

--- a/repo_test.go
+++ b/repo_test.go
@@ -719,8 +719,8 @@ func (rs *RepoSuite) TestCommit(c *C) {
 	r, err := NewRepo(local)
 	c.Assert(err, IsNil)
 
-	// commit without root.json
-	c.Assert(r.Commit(), DeepEquals, ErrMissingMetadata{"root.json"})
+	// commit without targets.json
+	c.Assert(r.Commit(), DeepEquals, ErrMissingMetadata{"targets.json"})
 
 	// Init should create targets.json, but not signed yet
 	r.Init(false)


### PR DESCRIPTION
Fixes #272

Release Notes: @trishankatdatadog and I worked on this issue to have a new field for `NewRoot()` and `NewTargets()`. This new field stores a boolean value that gets set to True if either of the functions mentioned above are used. This makes sure that the newly created target/ root file doesn't have it's `Version` incremented as it's not staged.

**Types of changes**:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). **Please ensure that your PR title** is a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) breaking change (with a `!`, as in `feat!: change foo`). 

**Description of the changes being introduced by the pull request**:

**Please verify and check that the pull request fulfills the following requirements**:

- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature
