### PR TITLE
docs: Update MAINTAINERS

### DIFF
--- a/docs/MAINTAINERS
+++ b/docs/MAINTAINERS
@@ -3,5 +3,4 @@ Trishank Karthik Kuppusamy <trishank.kuppusamy@datadoghq.com> (github: trishanka
 Joshua Lock <jlock@vmware.com> (github: joshuagl)
 Marina Moore <mm9693@nyu.edu> (github: mnm678)
 Zack Newman <zjn@chainguard.dev> (github: znewman01)
-Hossein Siadati <hossein.siadati@datadoghq.com> (github: hosseinsia)
 Radoslav Dimitrov <dimitrovr@vmware.com> (github: rdimitrov)


### PR DESCRIPTION
Remove @hosseinsia from list of maintainers. Thanks for your service!

Signed-off-by: Trishank Karthik Kuppusamy <trishank.kuppusamy@datadoghq.com>