### PR TITLE
docs: Use Github's vulnerability reporting

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -8,7 +8,8 @@ You may report issues for the most recent version of go-tuf. We will not retroac
 
 ## Reporting a Vulnerability
 
-If you discover a potential security issue in this project we ask that you notify the go-tuf maintainers via our [vulnerability reporting form](https://forms.gle/ShM4s3mLbUAx5QHo8). At the minimum, the report must contain the following:
+If you discover a potential security issue in this project we ask that you notify the go-tuf maintainers via [Github's private reporting feature](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability). At the minimum, the report must contain the following:
+
 * A description of the issue.
 * A specific version or commit SHA of `go-tuf` where the issue reproduces.
 * Instructions to reproduce the issue.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -8,7 +8,7 @@ You may report issues for the most recent version of go-tuf. We will not retroac
 
 ## Reporting a Vulnerability
 
-If you discover a potential security issue in this project we ask that you notify the go-tuf maintainers via [Github's private reporting feature](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability). At the minimum, the report must contain the following:
+If you discover a potential security issue in this project we ask that you notify the go-tuf maintainers via [Github's private reporting feature](https://github.com/theupdateframework/go-tuf/security/advisories/new) (requires being signed in to GitHub). At the minimum, the report must contain the following:
 
 * A description of the issue.
 * A specific version or commit SHA of `go-tuf` where the issue reproduces.


### PR DESCRIPTION
We can replace the Google form with Github's new vulnerability reporting feature! This will ensure that the set of folks who receive reports automatically syncs with current maintainers. More information about this feature is available [here](https://github.blog/changelog/2022-11-09-privately-report-vulnerabilities-to-repository-maintainers/).

This should only be merged after @joshuagl presses the button to enable this feature.