### PR TITLE
chore: elevate GitHub token permissions for release.yml workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
     tags:
       - "v*"
 name: CI
+permissions:
+  contents: write
 jobs:
   tests:
     uses: ./.github/workflows/tests.yml


### PR DESCRIPTION
The following PR elevates the GitHub Token permissions for the release workflows.

Signed-off-by: Radoslav Dimitrov <dimitrovr@vmware.com>

Please fill in the fields below to submit a pull request.  The more information that is provided, the better.

Fixes #436 

Release Notes: <!-- What comments/remarks should we include in the release notes for this change? -->

**Types of changes**:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). **Please ensure that your PR title** is a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) breaking change (with a `!`, as in `feat!: change foo`). 

**Description of the changes being introduced by the pull request**:

**Please verify and check that the pull request fulfills the following requirements**:

- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature
