### PR TITLE
test: add tests for rollback protection on snapshot, targets, delegations

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1328,6 +1328,7 @@ func (s *ClientSuite) TestRollbackDelegatedTargets(c *C) {
 	// rollback role.json version.
 	c.Assert(s.store.SetMeta("role.json", oldRole), IsNil)
 	repo, err := tuf.NewRepo(s.store)
+	c.Assert(err, IsNil)
 	c.Assert(repo.Snapshot(), IsNil)
 	c.Assert(repo.Timestamp(), IsNil)
 	c.Assert(repo.Commit(), IsNil)


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Fixes https://github.com/theupdateframework/go-tuf/issues/286

* client: adds testing for rollback protection on snapshot, targets, and delegated targets

Relevant: https://github.com/theupdateframework/go-tuf/issues/449

(Testing is already added for timestamp)