### PR TITLE
fix: golangci-lint failures when tested against Go 1.20

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,5 +66,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5
         with:
-          version: v1.49
+          version: v1.51 # has to be pinned and thus manually updated due to https://github.com/golangci/golangci-lint-action/blob/6a290f7d5d488e1e423b0b37fe802c822ca2c08c/README.md?plain=1#L108
           args: --timeout 5m --verbose

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,9 +1,3 @@
-run:
-  # Lint using Go 1.17, since some linters are disabled by default for Go 1.18
-  # until generics are supported.
-  # See https://github.com/golangci/golangci-lint/issues/2649
-  go: '1.17'
-
 linters:
   disable-all: true
   enable:


### PR DESCRIPTION
The following PR fixes the CI issues around Go 1.20 by updating the version of golangci-lint. It also removes the unnecessary version pin in its config file. 

The reason this has to be done manually is Dependabot takes care of updating the action, but the golangci-lint version has to be manually pinned because of our testing scenarios. For reference - https://github.com/golangci/golangci-lint-action/blob/6a290f7d5d488e1e423b0b37fe802c822ca2c08c/README.md?plain=1#L108

Signed-off-by: Radoslav Dimitrov <dimitrovr@vmware.com>

Please fill in the fields below to submit a pull request.  The more information that is provided, the better.

Fixes #455
Related to #454 

Release Notes: <!-- What comments/remarks should we include in the release notes for this change? -->

**Types of changes**:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). **Please ensure that your PR title** is a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) breaking change (with a `!`, as in `feat!: change foo`). 

**Description of the changes being introduced by the pull request**:

**Please verify and check that the pull request fulfills the following requirements**:

- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature
