### PR TITLE
ci: Disable daily checking for version but not security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,9 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
-    open-pull-requests-limit: 10
+    # Disable version updates, but not security updates:
+    # https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file
+    open-pull-requests-limit: 0
   # Monitor Github Actions
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -19,7 +21,9 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
-    open-pull-requests-limit: 10
+    # Disable version updates, but not security updates:
+    # https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file
+    open-pull-requests-limit: 0
   # Monitor Python test dependencies
   - package-ecosystem: "pip"
     directory: "/"
@@ -29,4 +33,6 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
-    open-pull-requests-limit: 10
+    # Disable version updates, but not security updates:
+    # https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file
+    open-pull-requests-limit: 0

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,35 +4,29 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
       time: "10:00"
     commit-message:
       prefix: "chore"
       include: "scope"
-    # Disable version updates, but not security updates:
-    # https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 10
   # Monitor Github Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
       time: "10:00"
     commit-message:
       prefix: "chore"
       include: "scope"
-    # Disable version updates, but not security updates:
-    # https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 10
   # Monitor Python test dependencies
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
       time: "10:00"
     commit-message:
       prefix: "chore"
       include: "scope"
-    # Disable version updates, but not security updates:
-    # https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Disable daily checking for version but not security updates.

Maybe we should also document a process for version updates when cutting a new release?