### PR TITLE
feat!: add deprecating message for the encrypted package

### DIFF
--- a/encrypted/encrypted.go
+++ b/encrypted/encrypted.go
@@ -3,6 +3,10 @@
 //
 // It uses scrypt derive a key from the passphrase and the NaCl secret box
 // cipher for authenticated encryption.
+//
+// Deprecated: The encrypted package from go-tuf is already moved to
+// https://github.com/secure-systems-lab/go-securesystemslib and will be deprecated here.
+// Use github.com/secure-systems-lab/go-securesystemslib/encrypted instead.
 package encrypted
 
 import (


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:

The following PR adds a message saying that the encrypted package from go-tuf is already moved to
https://github.com/secure-systems-lab/go-securesystemslib and will be deprecated here.

Existing dependants should use `github.com/secure-systems-lab/go-securesystemslib/encrypted` instead.

Release Notes: <!-- What comments/remarks should we include in the release notes for this change? -->

Deprecated: The encrypted package from go-tuf is already moved to
https://github.com/secure-systems-lab/go-securesystemslib and will be deprecated here.
Use github.com/secure-systems-lab/go-securesystemslib/encrypted instead.

**Types of changes**:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). **Please ensure that your PR title** is a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) breaking change (with a `!`, as in `feat!: change foo`). 

**Please verify and check that the pull request fulfills the following requirements**:

- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature
