### PR TITLE
docs: add Marvin Drees to the list of go-tuf maintainers

### DIFF
--- a/docs/MAINTAINERS
+++ b/docs/MAINTAINERS
@@ -2,5 +2,6 @@ Trishank Karthik Kuppusamy <trishank.kuppusamy@datadoghq.com> (github: trishanka
 Joshua Lock <jlock@vmware.com> (github: joshuagl)
 Marina Moore <mm9693@nyu.edu> (github: mnm678)
 Zack Newman <zjn@chainguard.dev> (github: znewman01)
-Radoslav Dimitrov <dimitrovr@vmware.com> (github: rdimitrov)
+Radoslav Dimitrov <radoslav@stacklok.com> (github: rdimitrov)
 Fredrik Skogman <kommendorkapten@github.com> (github: kommendorkapten)
+Marvin Drees <marvin.drees@9elements.com> (github: MDr164)


### PR DESCRIPTION
The following PR updates my employer email and adds Marvin Drees (@MDr164) to the list of go-tuf maintainers!  🎉 