### PR TITLE
Update license from BSD-2-Clause to Apache-2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,19 @@
-# Copyright 2022-2023 VMware, Inc.
 #
-# This product is licensed to you under the BSD-2 license (the "License").
-# You may not use this product except in compliance with the BSD-2 License.
-# This product may include a number of subcomponents with separate copyright
-# notices and license terms. Your use of these subcomponents is subject to
-# the terms and conditions of the subcomponent's license, as noted in the
-# LICENSE file.
+# Copyright 2024 The Update Framework Authors
 #
-# SPDX-License-Identifier: BSD-2-Clause
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+#
+# SPDX-License-Identifier: Apache-2.0
 on:
   pull_request:
   push:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,13 +1,19 @@
-# Copyright 2022-2023 VMware, Inc.
 #
-# This product is licensed to you under the BSD-2 license (the "License").
-# You may not use this product except in compliance with the BSD-2 License.
-# This product may include a number of subcomponents with separate copyright
-# notices and license terms. Your use of these subcomponents is subject to
-# the terms and conditions of the subcomponent's license, as noted in the
-# LICENSE file.
+# Copyright 2024 The Update Framework Authors
 #
-# SPDX-License-Identifier: BSD-2-Clause
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+#
+# SPDX-License-Identifier: Apache-2.0
 on:
   workflow_call:
 name: Examples # not exactly right to test functionality in such a way but it does act as a set of end to end test cases for the time being, nevertheless should be updated

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,13 +1,19 @@
-# Copyright 2022-2023 VMware, Inc.
 #
-# This product is licensed to you under the BSD-2 license (the "License").
-# You may not use this product except in compliance with the BSD-2 License.
-# This product may include a number of subcomponents with separate copyright
-# notices and license terms. Your use of these subcomponents is subject to
-# the terms and conditions of the subcomponent's license, as noted in the
-# LICENSE file.
+# Copyright 2024 The Update Framework Authors
 #
-# SPDX-License-Identifier: BSD-2-Clause
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+#
+# SPDX-License-Identifier: Apache-2.0
 on:
   workflow_call:
 name: Linting

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,13 +1,19 @@
-# Copyright 2022-2023 VMware, Inc.
 #
-# This product is licensed to you under the BSD-2 license (the "License").
-# You may not use this product except in compliance with the BSD-2 License.
-# This product may include a number of subcomponents with separate copyright
-# notices and license terms. Your use of these subcomponents is subject to
-# the terms and conditions of the subcomponent's license, as noted in the
-# LICENSE file.
+# Copyright 2024 The Update Framework Authors
 #
-# SPDX-License-Identifier: BSD-2-Clause
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+#
+# SPDX-License-Identifier: Apache-2.0
 on:
   workflow_call:
 name: Tests

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,13 +1,20 @@
-# Copyright 2022-2023 VMware, Inc.
 #
-# This product is licensed to you under the BSD-2 license (the "License").
-# You may not use this product except in compliance with the BSD-2 License.
-# This product may include a number of subcomponents with separate copyright
-# notices and license terms. Your use of these subcomponents is subject to
-# the terms and conditions of the subcomponent's license, as noted in the
-# LICENSE file.
+# Copyright 2024 The Update Framework Authors
 #
-# SPDX-License-Identifier: BSD-2-Clause
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+#
+# SPDX-License-Identifier: Apache-2.0
+
 run:
   linters:
   enable:

--- a/.minder.yaml
+++ b/.minder.yaml
@@ -109,7 +109,7 @@ repository:
   - type: license
     def:
       license_filename: LICENSE
-      license_type: "BSD-2-Clause"
+      license_type: "Apache License"
 # artifact:
 #   - type: artifact_signature
 #     params:

--- a/LICENSE
+++ b/LICENSE
@@ -1,13 +1,201 @@
-Copyright 2022-2023 VMware, Inc.
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-The BSD-2-Clause license (the "License") set forth below applies to all parts of the go-tuf-metadata project. You may not use this file except in compliance with the License.
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-BSD-2-Clause License
+   1. Definitions.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
 
-Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2024 The Update Framework Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,19 @@
-# Copyright 2023 VMware, Inc.
 #
-# This product is licensed to you under the BSD-2 license (the "License").
-# You may not use this product except in compliance with the BSD-2 License.
-# This product may include a number of subcomponents with separate copyright
-# notices and license terms. Your use of these subcomponents is subject to
-# the terms and conditions of the subcomponent's license, as noted in the
-# LICENSE file.
+# Copyright 2024 The Update Framework Authors
 #
-# SPDX-License-Identifier: BSD-2-Clause
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+#
+# SPDX-License-Identifier: Apache-2.0
 
 # We want to use bash
 SHELL:=/bin/bash

--- a/NOTICE
+++ b/NOTICE
@@ -1,10 +1,9 @@
-Copyright 2022-2023 VMware, Inc.
+Copyright 2024 The Update Framework Authors
 
-This product is licensed to you under the BSD-2 license (the "License").
-You may not use this product except in compliance with the BSD-2 License.
-This product may include a number of subcomponents with separate copyright
-notices and license terms. Your use of these subcomponents is subject to
-the terms and conditions of the subcomponent's license, as noted in the
-LICENSE file.
+Apache 2.0 License
+Copyright 2024 The Apache Software Foundation
 
-SPDX-License-Identifier: BSD-2-Clause
+This product includes software developed at
+The Apache Software Foundation (/).
+
+SPDX-License-Identifier: Apache-2.0

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![codecov](https://codecov.io/github/rdimitrov/go-tuf-metadata/branch/main/graph/badge.svg?token=2ZUA68ZL13)](https://codecov.io/github/rdimitrov/go-tuf-metadata)
 [![Go Reference](https://pkg.go.dev/badge/github.com/rdimitrov/go-tuf-metadata.svg)](https://pkg.go.dev/github.com/rdimitrov/go-tuf-metadata)
 [![Go Report Card](https://goreportcard.com/badge/github.com/rdimitrov/go-tuf-metadata)](https://goreportcard.com/report/github.com/rdimitrov/go-tuf-metadata)
-[![License](https://img.shields.io/badge/License-BSD_2--Clause-orange.svg)](https://opensource.org/licenses/BSD-2-Clause)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 # <img src="https://cdn.rawgit.com/theupdateframework/artwork/3a649fa6/tuf-logo.svg" height="100" valign="middle" alt="TUF"/> A Framework for Securing Software Update Systems
 

--- a/examples/cli/tuf-client/cmd/get.go
+++ b/examples/cli/tuf-client/cmd/get.go
@@ -1,13 +1,19 @@
-// Copyright 2022-2023 VMware, Inc.
+// Copyright 2024 The Update Framework Authors
 //
-// This product is licensed to you under the BSD-2 license (the "License").
-// You may not use this product except in compliance with the BSD-2 License.
-// This product may include a number of subcomponents with separate copyright
-// notices and license terms. Your use of these subcomponents is subject to
-// the terms and conditions of the subcomponent's license, as noted in the
-// LICENSE file.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: BSD-2-Clause
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+//
+// SPDX-License-Identifier: Apache-2.0
+//
 
 package cmd
 

--- a/examples/cli/tuf-client/cmd/init.go
+++ b/examples/cli/tuf-client/cmd/init.go
@@ -1,13 +1,19 @@
-// Copyright 2022-2023 VMware, Inc.
+// Copyright 2024 The Update Framework Authors
 //
-// This product is licensed to you under the BSD-2 license (the "License").
-// You may not use this product except in compliance with the BSD-2 License.
-// This product may include a number of subcomponents with separate copyright
-// notices and license terms. Your use of these subcomponents is subject to
-// the terms and conditions of the subcomponent's license, as noted in the
-// LICENSE file.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: BSD-2-Clause
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+//
+// SPDX-License-Identifier: Apache-2.0
+//
 
 package cmd
 

--- a/examples/cli/tuf-client/cmd/reset.go
+++ b/examples/cli/tuf-client/cmd/reset.go
@@ -1,13 +1,19 @@
-// Copyright 2022-2023 VMware, Inc.
+// Copyright 2024 The Update Framework Authors
 //
-// This product is licensed to you under the BSD-2 license (the "License").
-// You may not use this product except in compliance with the BSD-2 License.
-// This product may include a number of subcomponents with separate copyright
-// notices and license terms. Your use of these subcomponents is subject to
-// the terms and conditions of the subcomponent's license, as noted in the
-// LICENSE file.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: BSD-2-Clause
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+//
+// SPDX-License-Identifier: Apache-2.0
+//
 
 package cmd
 

--- a/examples/cli/tuf-client/cmd/root.go
+++ b/examples/cli/tuf-client/cmd/root.go
@@ -1,13 +1,19 @@
-// Copyright 2022-2023 VMware, Inc.
+// Copyright 2024 The Update Framework Authors
 //
-// This product is licensed to you under the BSD-2 license (the "License").
-// You may not use this product except in compliance with the BSD-2 License.
-// This product may include a number of subcomponents with separate copyright
-// notices and license terms. Your use of these subcomponents is subject to
-// the terms and conditions of the subcomponent's license, as noted in the
-// LICENSE file.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: BSD-2-Clause
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+//
+// SPDX-License-Identifier: Apache-2.0
+//
 
 package cmd
 

--- a/examples/cli/tuf-client/main.go
+++ b/examples/cli/tuf-client/main.go
@@ -1,13 +1,19 @@
-// Copyright 2022-2023 VMware, Inc.
+// Copyright 2024 The Update Framework Authors
 //
-// This product is licensed to you under the BSD-2 license (the "License").
-// You may not use this product except in compliance with the BSD-2 License.
-// This product may include a number of subcomponents with separate copyright
-// notices and license terms. Your use of these subcomponents is subject to
-// the terms and conditions of the subcomponent's license, as noted in the
-// LICENSE file.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: BSD-2-Clause
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+//
+// SPDX-License-Identifier: Apache-2.0
+//
 
 package main
 

--- a/examples/cli/tuf/cmd/init.go
+++ b/examples/cli/tuf/cmd/init.go
@@ -1,13 +1,19 @@
-// Copyright 2022-2023 VMware, Inc.
+// Copyright 2024 The Update Framework Authors
 //
-// This product is licensed to you under the BSD-2 license (the "License").
-// You may not use this product except in compliance with the BSD-2 License.
-// This product may include a number of subcomponents with separate copyright
-// notices and license terms. Your use of these subcomponents is subject to
-// the terms and conditions of the subcomponent's license, as noted in the
-// LICENSE file.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: BSD-2-Clause
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+//
+// SPDX-License-Identifier: Apache-2.0
+//
 
 package cmd
 

--- a/examples/cli/tuf/cmd/root.go
+++ b/examples/cli/tuf/cmd/root.go
@@ -1,13 +1,19 @@
-// Copyright 2022-2023 VMware, Inc.
+// Copyright 2024 The Update Framework Authors
 //
-// This product is licensed to you under the BSD-2 license (the "License").
-// You may not use this product except in compliance with the BSD-2 License.
-// This product may include a number of subcomponents with separate copyright
-// notices and license terms. Your use of these subcomponents is subject to
-// the terms and conditions of the subcomponent's license, as noted in the
-// LICENSE file.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: BSD-2-Clause
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+//
+// SPDX-License-Identifier: Apache-2.0
+//
 
 package cmd
 

--- a/examples/cli/tuf/main.go
+++ b/examples/cli/tuf/main.go
@@ -1,13 +1,19 @@
-// Copyright 2022-2023 VMware, Inc.
+// Copyright 2024 The Update Framework Authors
 //
-// This product is licensed to you under the BSD-2 license (the "License").
-// You may not use this product except in compliance with the BSD-2 License.
-// This product may include a number of subcomponents with separate copyright
-// notices and license terms. Your use of these subcomponents is subject to
-// the terms and conditions of the subcomponent's license, as noted in the
-// LICENSE file.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: BSD-2-Clause
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+//
+// SPDX-License-Identifier: Apache-2.0
+//
 
 package main
 

--- a/examples/client/client_example.go
+++ b/examples/client/client_example.go
@@ -1,13 +1,19 @@
-// Copyright 2022-2023 VMware, Inc.
+// Copyright 2024 The Update Framework Authors
 //
-// This product is licensed to you under the BSD-2 license (the "License").
-// You may not use this product except in compliance with the BSD-2 License.
-// This product may include a number of subcomponents with separate copyright
-// notices and license terms. Your use of these subcomponents is subject to
-// the terms and conditions of the subcomponent's license, as noted in the
-// LICENSE file.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: BSD-2-Clause
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+//
+// SPDX-License-Identifier: Apache-2.0
+//
 
 package main
 

--- a/examples/multirepo/client/client_example.go
+++ b/examples/multirepo/client/client_example.go
@@ -1,13 +1,19 @@
-// Copyright 2023 VMware, Inc.
+// Copyright 2024 The Update Framework Authors
 //
-// This product is licensed to you under the BSD-2 license (the "License").
-// You may not use this product except in compliance with the BSD-2 License.
-// This product may include a number of subcomponents with separate copyright
-// notices and license terms. Your use of these subcomponents is subject to
-// the terms and conditions of the subcomponent's license, as noted in the
-// LICENSE file.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: BSD-2-Clause
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+//
+// SPDX-License-Identifier: Apache-2.0
+//
 
 package main
 

--- a/examples/multirepo/repository/generate_metadata.go
+++ b/examples/multirepo/repository/generate_metadata.go
@@ -1,13 +1,19 @@
-// Copyright 2023 VMware, Inc.
+// Copyright 2024 The Update Framework Authors
 //
-// This product is licensed to you under the BSD-2 license (the "License").
-// You may not use this product except in compliance with the BSD-2 License.
-// This product may include a number of subcomponents with separate copyright
-// notices and license terms. Your use of these subcomponents is subject to
-// the terms and conditions of the subcomponent's license, as noted in the
-// LICENSE file.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: BSD-2-Clause
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+//
+// SPDX-License-Identifier: Apache-2.0
+//
 
 package main
 

--- a/examples/repository/basic_repository.go
+++ b/examples/repository/basic_repository.go
@@ -1,13 +1,19 @@
-// Copyright 2022-2023 VMware, Inc.
+// Copyright 2024 The Update Framework Authors
 //
-// This product is licensed to you under the BSD-2 license (the "License").
-// You may not use this product except in compliance with the BSD-2 License.
-// This product may include a number of subcomponents with separate copyright
-// notices and license terms. Your use of these subcomponents is subject to
-// the terms and conditions of the subcomponent's license, as noted in the
-// LICENSE file.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: BSD-2-Clause
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+//
+// SPDX-License-Identifier: Apache-2.0
+//
 
 package main
 

--- a/metadata/config/config.go
+++ b/metadata/config/config.go
@@ -1,13 +1,19 @@
-// Copyright 2022-2023 VMware, Inc.
+// Copyright 2024 The Update Framework Authors
 //
-// This product is licensed to you under the BSD-2 license (the "License").
-// You may not use this product except in compliance with the BSD-2 License.
-// This product may include a number of subcomponents with separate copyright
-// notices and license terms. Your use of these subcomponents is subject to
-// the terms and conditions of the subcomponent's license, as noted in the
-// LICENSE file.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: BSD-2-Clause
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+//
+// SPDX-License-Identifier: Apache-2.0
+//
 
 package config
 

--- a/metadata/config/config_test.go
+++ b/metadata/config/config_test.go
@@ -1,13 +1,19 @@
-// Copyright 2023 VMware, Inc.
+// Copyright 2024 The Update Framework Authors
 //
-// This product is licensed to you under the BSD-2 license (the "License").
-// You may not use this product except in compliance with the BSD-2 License.
-// This product may include a number of subcomponents with separate copyright
-// notices and license terms. Your use of these subcomponents is subject to
-// the terms and conditions of the subcomponent's license, as noted in the
-// LICENSE file.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: BSD-2-Clause
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+//
+// SPDX-License-Identifier: Apache-2.0
+//
 
 package config
 

--- a/metadata/errors.go
+++ b/metadata/errors.go
@@ -1,13 +1,19 @@
-// Copyright 2022-2023 VMware, Inc.
+// Copyright 2024 The Update Framework Authors
 //
-// This product is licensed to you under the BSD-2 license (the "License").
-// You may not use this product except in compliance with the BSD-2 License.
-// This product may include a number of subcomponents with separate copyright
-// notices and license terms. Your use of these subcomponents is subject to
-// the terms and conditions of the subcomponent's license, as noted in the
-// LICENSE file.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: BSD-2-Clause
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+//
+// SPDX-License-Identifier: Apache-2.0
+//
 
 package metadata
 

--- a/metadata/fetcher/fetcher.go
+++ b/metadata/fetcher/fetcher.go
@@ -1,13 +1,19 @@
-// Copyright 2022-2023 VMware, Inc.
+// Copyright 2024 The Update Framework Authors
 //
-// This product is licensed to you under the BSD-2 license (the "License").
-// You may not use this product except in compliance with the BSD-2 License.
-// This product may include a number of subcomponents with separate copyright
-// notices and license terms. Your use of these subcomponents is subject to
-// the terms and conditions of the subcomponent's license, as noted in the
-// LICENSE file.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: BSD-2-Clause
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+//
+// SPDX-License-Identifier: Apache-2.0
+//
 
 package fetcher
 

--- a/metadata/fetcher/fetcher_test.go
+++ b/metadata/fetcher/fetcher_test.go
@@ -1,13 +1,19 @@
-// Copyright 2023 VMware, Inc.
+// Copyright 2024 The Update Framework Authors
 //
-// This product is licensed to you under the BSD-2 license (the "License").
-// You may not use this product except in compliance with the BSD-2 License.
-// This product may include a number of subcomponents with separate copyright
-// notices and license terms. Your use of these subcomponents is subject to
-// the terms and conditions of the subcomponent's license, as noted in the
-// LICENSE file.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: BSD-2-Clause
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+//
+// SPDX-License-Identifier: Apache-2.0
+//
 
 package fetcher
 

--- a/metadata/keys.go
+++ b/metadata/keys.go
@@ -1,13 +1,19 @@
-// Copyright 2022-2023 VMware, Inc.
+// Copyright 2024 The Update Framework Authors
 //
-// This product is licensed to you under the BSD-2 license (the "License").
-// You may not use this product except in compliance with the BSD-2 License.
-// This product may include a number of subcomponents with separate copyright
-// notices and license terms. Your use of these subcomponents is subject to
-// the terms and conditions of the subcomponent's license, as noted in the
-// LICENSE file.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: BSD-2-Clause
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+//
+// SPDX-License-Identifier: Apache-2.0
+//
 
 package metadata
 

--- a/metadata/logger.go
+++ b/metadata/logger.go
@@ -1,13 +1,19 @@
-// Copyright 2023 VMware, Inc.
+// Copyright 2024 The Update Framework Authors
 //
-// This product is licensed to you under the BSD-2 license (the "License").
-// You may not use this product except in compliance with the BSD-2 License.
-// This product may include a number of subcomponents with separate copyright
-// notices and license terms. Your use of these subcomponents is subject to
-// the terms and conditions of the subcomponent's license, as noted in the
-// LICENSE file.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: BSD-2-Clause
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+//
+// SPDX-License-Identifier: Apache-2.0
+//
 
 package metadata
 

--- a/metadata/logger_test.go
+++ b/metadata/logger_test.go
@@ -1,13 +1,19 @@
-// Copyright 2023 VMware, Inc.
+// Copyright 2024 The Update Framework Authors
 //
-// This product is licensed to you under the BSD-2 license (the "License").
-// You may not use this product except in compliance with the BSD-2 License.
-// This product may include a number of subcomponents with separate copyright
-// notices and license terms. Your use of these subcomponents is subject to
-// the terms and conditions of the subcomponent's license, as noted in the
-// LICENSE file.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: BSD-2-Clause
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+//
+// SPDX-License-Identifier: Apache-2.0
+//
 
 package metadata
 

--- a/metadata/marshal.go
+++ b/metadata/marshal.go
@@ -1,13 +1,19 @@
-// Copyright 2023 VMware, Inc.
+// Copyright 2024 The Update Framework Authors
 //
-// This product is licensed to you under the BSD-2 license (the "License").
-// You may not use this product except in compliance with the BSD-2 License.
-// This product may include a number of subcomponents with separate copyright
-// notices and license terms. Your use of these subcomponents is subject to
-// the terms and conditions of the subcomponent's license, as noted in the
-// LICENSE file.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: BSD-2-Clause
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+//
+// SPDX-License-Identifier: Apache-2.0
+//
 
 package metadata
 

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -1,13 +1,19 @@
-// Copyright 2022-2023 VMware, Inc.
+// Copyright 2024 The Update Framework Authors
 //
-// This product is licensed to you under the BSD-2 license (the "License").
-// You may not use this product except in compliance with the BSD-2 License.
-// This product may include a number of subcomponents with separate copyright
-// notices and license terms. Your use of these subcomponents is subject to
-// the terms and conditions of the subcomponent's license, as noted in the
-// LICENSE file.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: BSD-2-Clause
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+//
+// SPDX-License-Identifier: Apache-2.0
+//
 
 package metadata
 

--- a/metadata/metadata_api_test.go
+++ b/metadata/metadata_api_test.go
@@ -1,13 +1,19 @@
-// Copyright 2023 VMware, Inc.
+// Copyright 2024 The Update Framework Authors
 //
-// This product is licensed to you under the BSD-2 license (the "License").
-// You may not use this product except in compliance with the BSD-2 License.
-// This product may include a number of subcomponents with separate copyright
-// notices and license terms. Your use of these subcomponents is subject to
-// the terms and conditions of the subcomponent's license, as noted in the
-// LICENSE file.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: BSD-2-Clause
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+//
+// SPDX-License-Identifier: Apache-2.0
+//
 
 package metadata
 

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -1,13 +1,19 @@
-// Copyright 2022-2023 VMware, Inc.
+// Copyright 2024 The Update Framework Authors
 //
-// This product is licensed to you under the BSD-2 license (the "License").
-// You may not use this product except in compliance with the BSD-2 License.
-// This product may include a number of subcomponents with separate copyright
-// notices and license terms. Your use of these subcomponents is subject to
-// the terms and conditions of the subcomponent's license, as noted in the
-// LICENSE file.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: BSD-2-Clause
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+//
+// SPDX-License-Identifier: Apache-2.0
+//
 
 package metadata
 

--- a/metadata/multirepo/multirepo.go
+++ b/metadata/multirepo/multirepo.go
@@ -1,13 +1,19 @@
-// Copyright 2022-2023 VMware, Inc.
+// Copyright 2024 The Update Framework Authors
 //
-// This product is licensed to you under the BSD-2 license (the "License").
-// You may not use this product except in compliance with the BSD-2 License.
-// This product may include a number of subcomponents with separate copyright
-// notices and license terms. Your use of these subcomponents is subject to
-// the terms and conditions of the subcomponent's license, as noted in the
-// LICENSE file.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: BSD-2-Clause
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+//
+// SPDX-License-Identifier: Apache-2.0
+//
 
 package multirepo
 

--- a/metadata/repository/repository.go
+++ b/metadata/repository/repository.go
@@ -1,13 +1,19 @@
-// Copyright 2022-2023 VMware, Inc.
+// Copyright 2024 The Update Framework Authors
 //
-// This product is licensed to you under the BSD-2 license (the "License").
-// You may not use this product except in compliance with the BSD-2 License.
-// This product may include a number of subcomponents with separate copyright
-// notices and license terms. Your use of these subcomponents is subject to
-// the terms and conditions of the subcomponent's license, as noted in the
-// LICENSE file.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: BSD-2-Clause
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+//
+// SPDX-License-Identifier: Apache-2.0
+//
 
 package repository
 

--- a/metadata/repository/repository_test.go
+++ b/metadata/repository/repository_test.go
@@ -1,13 +1,19 @@
-// Copyright 2023 VMware, Inc.
+// Copyright 2024 The Update Framework Authors
 //
-// This product is licensed to you under the BSD-2 license (the "License").
-// You may not use this product except in compliance with the BSD-2 License.
-// This product may include a number of subcomponents with separate copyright
-// notices and license terms. Your use of these subcomponents is subject to
-// the terms and conditions of the subcomponent's license, as noted in the
-// LICENSE file.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: BSD-2-Clause
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+//
+// SPDX-License-Identifier: Apache-2.0
+//
 
 package repository
 

--- a/metadata/trustedmetadata/trustedmetadata.go
+++ b/metadata/trustedmetadata/trustedmetadata.go
@@ -1,13 +1,19 @@
-// Copyright 2022-2023 VMware, Inc.
+// Copyright 2024 The Update Framework Authors
 //
-// This product is licensed to you under the BSD-2 license (the "License").
-// You may not use this product except in compliance with the BSD-2 License.
-// This product may include a number of subcomponents with separate copyright
-// notices and license terms. Your use of these subcomponents is subject to
-// the terms and conditions of the subcomponent's license, as noted in the
-// LICENSE file.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: BSD-2-Clause
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+//
+// SPDX-License-Identifier: Apache-2.0
+//
 
 package trustedmetadata
 

--- a/metadata/trustedmetadata/trustedmetadata_test.go
+++ b/metadata/trustedmetadata/trustedmetadata_test.go
@@ -1,13 +1,19 @@
-// Copyright 2023 VMware, Inc.
+// Copyright 2024 The Update Framework Authors
 //
-// This product is licensed to you under the BSD-2 license (the "License").
-// You may not use this product except in compliance with the BSD-2 License.
-// This product may include a number of subcomponents with separate copyright
-// notices and license terms. Your use of these subcomponents is subject to
-// the terms and conditions of the subcomponent's license, as noted in the
-// LICENSE file.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: BSD-2-Clause
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+//
+// SPDX-License-Identifier: Apache-2.0
+//
 
 package trustedmetadata
 

--- a/metadata/types.go
+++ b/metadata/types.go
@@ -1,13 +1,19 @@
-// Copyright 2022-2023 VMware, Inc.
+// Copyright 2024 The Update Framework Authors
 //
-// This product is licensed to you under the BSD-2 license (the "License").
-// You may not use this product except in compliance with the BSD-2 License.
-// This product may include a number of subcomponents with separate copyright
-// notices and license terms. Your use of these subcomponents is subject to
-// the terms and conditions of the subcomponent's license, as noted in the
-// LICENSE file.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: BSD-2-Clause
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+//
+// SPDX-License-Identifier: Apache-2.0
+//
 
 package metadata
 

--- a/metadata/updater/updater.go
+++ b/metadata/updater/updater.go
@@ -1,13 +1,19 @@
-// Copyright 2022-2023 VMware, Inc.
+// Copyright 2024 The Update Framework Authors
 //
-// This product is licensed to you under the BSD-2 license (the "License").
-// You may not use this product except in compliance with the BSD-2 License.
-// This product may include a number of subcomponents with separate copyright
-// notices and license terms. Your use of these subcomponents is subject to
-// the terms and conditions of the subcomponent's license, as noted in the
-// LICENSE file.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: BSD-2-Clause
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+//
+// SPDX-License-Identifier: Apache-2.0
+//
 
 package updater
 

--- a/metadata/updater/updater_consistent_snapshot_test.go
+++ b/metadata/updater/updater_consistent_snapshot_test.go
@@ -1,13 +1,19 @@
-// Copyright 2023 VMware, Inc.
+// Copyright 2024 The Update Framework Authors
 //
-// This product is licensed to you under the BSD-2 license (the "License").
-// You may not use this product except in compliance with the BSD-2 License.
-// This product may include a number of subcomponents with separate copyright
-// notices and license terms. Your use of these subcomponents is subject to
-// the terms and conditions of the subcomponent's license, as noted in the
-// LICENSE file.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: BSD-2-Clause
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+//
+// SPDX-License-Identifier: Apache-2.0
+//
 
 package updater
 

--- a/metadata/updater/updater_top_level_update_test.go
+++ b/metadata/updater/updater_top_level_update_test.go
@@ -1,13 +1,19 @@
-// Copyright 2023 VMware, Inc.
+// Copyright 2024 The Update Framework Authors
 //
-// This product is licensed to you under the BSD-2 license (the "License").
-// You may not use this product except in compliance with the BSD-2 License.
-// This product may include a number of subcomponents with separate copyright
-// notices and license terms. Your use of these subcomponents is subject to
-// the terms and conditions of the subcomponent's license, as noted in the
-// LICENSE file.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: BSD-2-Clause
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+//
+// SPDX-License-Identifier: Apache-2.0
+//
 
 package updater
 

--- a/testutils/simulator/repository_simulator.go
+++ b/testutils/simulator/repository_simulator.go
@@ -1,13 +1,19 @@
-// Copyright 2023 VMware, Inc.
+// Copyright 2024 The Update Framework Authors
 //
-// This product is licensed to you under the BSD-2 license (the "License").
-// You may not use this product except in compliance with the BSD-2 License.
-// This product may include a number of subcomponents with separate copyright
-// notices and license terms. Your use of these subcomponents is subject to
-// the terms and conditions of the subcomponent's license, as noted in the
-// LICENSE file.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: BSD-2-Clause
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+//
+// SPDX-License-Identifier: Apache-2.0
+//
 
 package simulator
 

--- a/testutils/simulator/repository_simulator_setup.go
+++ b/testutils/simulator/repository_simulator_setup.go
@@ -1,13 +1,19 @@
-// Copyright 2023 VMware, Inc.
+// Copyright 2024 The Update Framework Authors
 //
-// This product is licensed to you under the BSD-2 license (the "License").
-// You may not use this product except in compliance with the BSD-2 License.
-// This product may include a number of subcomponents with separate copyright
-// notices and license terms. Your use of these subcomponents is subject to
-// the terms and conditions of the subcomponent's license, as noted in the
-// LICENSE file.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: BSD-2-Clause
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+//
+// SPDX-License-Identifier: Apache-2.0
+//
 
 package simulator
 

--- a/testutils/testutils/setup.go
+++ b/testutils/testutils/setup.go
@@ -1,13 +1,19 @@
-// Copyright 2023 VMware, Inc.
+// Copyright 2024 The Update Framework Authors
 //
-// This product is licensed to you under the BSD-2 license (the "License").
-// You may not use this product except in compliance with the BSD-2 License.
-// This product may include a number of subcomponents with separate copyright
-// notices and license terms. Your use of these subcomponents is subject to
-// the terms and conditions of the subcomponent's license, as noted in the
-// LICENSE file.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: BSD-2-Clause
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+//
+// SPDX-License-Identifier: Apache-2.0
+//
 
 package testutils
 


### PR DESCRIPTION
The following change is motivated by the donation of https://github.com/rdimitrov/go-tuf-metadata to https://github.com/theupdateframework/go-tuf which is a CNCF graduated project. 

The CNCF's preferred license type is Apache-2.0 and as a result the maintainers of go-tuf decided to align the project's license file with Apache-2.0.