### PR TITLE
Fixes for windows & enable in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,11 +32,14 @@ jobs:
     strategy:
       fail-fast: false # Keep running if one leg fails.
       matrix:
-        os: [ubuntu-latest] # , macos-latest, windows-latest] Enable later so we don't waste github actions resources
+        os: [ubuntu-latest, windows-latest] # , ] Enable later so we don't waste github actions resources
         go-version: ${{ fromJSON(needs.get-go-versions.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
     needs: get-go-versions
     steps:
+      - name: Set git to use LF
+        run: git config --global core.autocrlf false
+
       - name: Checkout code
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
 

--- a/examples/cli/tuf-client/cmd/get.go
+++ b/examples/cli/tuf-client/cmd/get.go
@@ -157,7 +157,7 @@ func verifyEnv() (*localConfig, error) {
 		return nil, fmt.Errorf("no local download folder: %w", err)
 	}
 	// verify there's a local root.json available for bootstrapping trust
-	_, err = os.Stat(fmt.Sprintf("%s/%s.json", env.MetadataDir, metadata.ROOT))
+	_, err = os.Stat(filepath.Join(env.MetadataDir, fmt.Sprintf("%s.json", metadata.ROOT)))
 	if err != nil {
 		return nil, fmt.Errorf("no local download folder: %w", err)
 	}

--- a/examples/cli/tuf-client/cmd/init.go
+++ b/examples/cli/tuf-client/cmd/init.go
@@ -75,7 +75,7 @@ func InitializeCmd() error {
 		if err != nil {
 			return err
 		}
-		rootPath = fmt.Sprintf("%s/%s.json", rootPath, metadata.ROOT)
+		rootPath = filepath.Join(rootPath, fmt.Sprintf("%s.json", metadata.ROOT))
 		// no need to copy root.json to the metadata folder as we already download it in the expected location
 		copyTrusted = false
 	}

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -21,8 +21,8 @@ import (
 	"crypto/ed25519"
 	"crypto/sha256"
 	"encoding/json"
-	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -506,7 +506,7 @@ func TestToByte(t *testing.T) {
 
 func TestFromFile(t *testing.T) {
 	root := Root(fixedExpire)
-	_, err := root.FromFile(fmt.Sprintf("%s/1.root.json", TEST_REPOSITORY_DATA))
+	_, err := root.FromFile(filepath.Join(TEST_REPOSITORY_DATA, "1.root.json"))
 	assert.NoError(t, err)
 
 	assert.Equal(t, fixedExpire, root.Signed.Expires)
@@ -554,7 +554,7 @@ func TestToFile(t *testing.T) {
 	tmpDir, err := os.MkdirTemp(tmp, "0750")
 	assert.NoError(t, err)
 
-	fileName := fmt.Sprintf("%s/1.root.json", tmpDir)
+	fileName := filepath.Join(tmpDir, "1.root.json")
 	assert.NoFileExists(t, fileName)
 	root, err := Root().FromBytes(testRootBytes)
 	assert.NoError(t, err)

--- a/metadata/trustedmetadata/trustedmetadata_test.go
+++ b/metadata/trustedmetadata/trustedmetadata_test.go
@@ -19,8 +19,8 @@ package trustedmetadata
 
 import (
 	"crypto"
-	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -38,39 +38,50 @@ func setAllRolesBytes(path string) {
 	log := metadata.GetLogger()
 
 	allRoles = make(map[string][]byte)
-	root, err := os.ReadFile(fmt.Sprintf("%s/root.json", path))
+	rootPath := filepath.Join(path, "root.json")
+	root, err := os.ReadFile(rootPath)
 	if err != nil {
-		log.Error(err, "failed to root bytes")
+		log.Error(err, "failed to read root bytes")
 		os.Exit(1)
 	}
 	allRoles[metadata.ROOT] = root
-	targets, err := os.ReadFile(fmt.Sprintf("%s/targets.json", path))
+
+	targetsPath := filepath.Join(path, "targets.json")
+	targets, err := os.ReadFile(targetsPath)
 	if err != nil {
-		log.Error(err, "failed to targets bytes")
+		log.Error(err, "failed to read targets bytes")
 		os.Exit(1)
 	}
 	allRoles[metadata.TARGETS] = targets
-	snapshot, err := os.ReadFile(fmt.Sprintf("%s/snapshot.json", path))
+
+	snapshotPath := filepath.Join(path, "snapshot.json")
+	snapshot, err := os.ReadFile(snapshotPath)
 	if err != nil {
-		log.Error(err, "failed to snapshot bytes")
+		log.Error(err, "failed to read snapshot bytes")
 		os.Exit(1)
 	}
 	allRoles[metadata.SNAPSHOT] = snapshot
-	timestamp, err := os.ReadFile(fmt.Sprintf("%s/timestamp.json", path))
+
+	timestampPath := filepath.Join(path, "timestamp.json")
+	timestamp, err := os.ReadFile(timestampPath)
 	if err != nil {
-		log.Error(err, "failed to timestamp bytes")
+		log.Error(err, "failed to read timestamp bytes")
 		os.Exit(1)
 	}
 	allRoles[metadata.TIMESTAMP] = timestamp
-	role1, err := os.ReadFile(fmt.Sprintf("%s/role1.json", path))
+
+	role1Path := filepath.Join(path, "role1.json")
+	role1, err := os.ReadFile(role1Path)
 	if err != nil {
-		log.Error(err, "failed to role1 bytes")
+		log.Error(err, "failed to read role1 bytes")
 		os.Exit(1)
 	}
 	allRoles["role1"] = role1
-	role2, err := os.ReadFile(fmt.Sprintf("%s/role2.json", path))
+
+	role2Path := filepath.Join(path, "role2.json")
+	role2, err := os.ReadFile(role2Path)
 	if err != nil {
-		log.Error(err, "failed to role2 bytes")
+		log.Error(err, "failed to read role2 bytes")
 		os.Exit(1)
 	}
 	allRoles["role2"] = role2
@@ -104,7 +115,7 @@ func modifyRootMetadata(fn modifyRoot) ([]byte, error) {
 	}
 	fn(root)
 
-	signer, err := signature.LoadSignerFromPEMFile(testutils.KeystoreDir+"/root_key", crypto.SHA256, cryptoutils.SkipPassword)
+	signer, err := signature.LoadSignerFromPEMFile(filepath.Join(testutils.KeystoreDir, "root_key"), crypto.SHA256, cryptoutils.SkipPassword)
 	if err != nil {
 		log.Error(err, "failed to load signer from pem file")
 	}
@@ -127,7 +138,7 @@ func modifyTimestamptMetadata(fn modifyTimestamp) ([]byte, error) {
 	}
 	fn(timestamp)
 
-	signer, err := signature.LoadSignerFromPEMFile(testutils.KeystoreDir+"/timestamp_key", crypto.SHA256, cryptoutils.SkipPassword)
+	signer, err := signature.LoadSignerFromPEMFile(filepath.Join(testutils.KeystoreDir, "timestamp_key"), crypto.SHA256, cryptoutils.SkipPassword)
 	if err != nil {
 		log.Error(err, "failed to load signer from pem file")
 	}
@@ -150,7 +161,7 @@ func modifySnapshotMetadata(fn modifySnapshot) ([]byte, error) {
 	}
 	fn(snapshot)
 
-	signer, err := signature.LoadSignerFromPEMFile(testutils.KeystoreDir+"/snapshot_key", crypto.SHA256, cryptoutils.SkipPassword)
+	signer, err := signature.LoadSignerFromPEMFile(filepath.Join(testutils.KeystoreDir, "snapshot_key"), crypto.SHA256, cryptoutils.SkipPassword)
 	if err != nil {
 		log.Error(err, "failed to load signer from pem file")
 	}
@@ -173,7 +184,7 @@ func modifyTargetsMetadata(fn modifyTargets) ([]byte, error) {
 	}
 	fn(targets)
 
-	signer, err := signature.LoadSignerFromPEMFile(testutils.KeystoreDir+"/targets_key", crypto.SHA256, cryptoutils.SkipPassword)
+	signer, err := signature.LoadSignerFromPEMFile(filepath.Join(testutils.KeystoreDir, "targets_key"), crypto.SHA256, cryptoutils.SkipPassword)
 	if err != nil {
 		log.Error(err, "failed to load signer from pem file")
 	}

--- a/metadata/updater/updater_consistent_snapshot_test.go
+++ b/metadata/updater/updater_consistent_snapshot_test.go
@@ -39,10 +39,12 @@ func TestTopLevelRolesUpdateWithConsistentSnapshotDisabled(t *testing.T) {
 	updaterConfig, err := loadUpdaterConfig()
 	assert.NoError(t, err)
 	updater := initUpdater(updaterConfig)
-
 	// cleanup fetch tracker metadata
 	simulator.Sim.FetchTracker.Metadata = []simulator.FTMetadata{}
 	err = updater.Refresh()
+	if err != nil {
+		t.Fatal(err)
+	}
 	assert.NoError(t, err)
 
 	// metadata files are fetched with the expected version (or None)
@@ -71,7 +73,9 @@ func TestTopLevelRolesUpdateWithConsistentSnapshotEnabled(t *testing.T) {
 	updaterConfig, err := loadUpdaterConfig()
 	assert.NoError(t, err)
 	updater := initUpdater(updaterConfig)
-
+	if updater == nil {
+		t.Fatal("updater is nil")
+	}
 	// cleanup fetch tracker metadata
 	simulator.Sim.FetchTracker.Metadata = []simulator.FTMetadata{}
 	err = updater.Refresh()
@@ -133,7 +137,9 @@ func TestDelegatesRolesUpdateWithConsistentSnapshotDisabled(t *testing.T) {
 	updaterConfig, err := loadUpdaterConfig()
 	assert.NoError(t, err)
 	updater := initUpdater(updaterConfig)
-
+	if updater == nil {
+		t.Fatal("updater is nil")
+	}
 	err = updater.Refresh()
 	assert.NoError(t, err)
 
@@ -149,7 +155,7 @@ func TestDelegatesRolesUpdateWithConsistentSnapshotDisabled(t *testing.T) {
 		{Name: "..", Value: -1},
 		{Name: ".", Value: -1},
 	}
-	assert.EqualValues(t, expectedsnapshotEnabled, simulator.Sim.FetchTracker.Metadata)
+	assert.ElementsMatch(t, expectedsnapshotEnabled, simulator.Sim.FetchTracker.Metadata)
 	// metadata files are always persisted without a version prefix
 	assertFilesExist(t, metadata.TOP_LEVEL_ROLE_NAMES[:])
 }
@@ -197,7 +203,9 @@ func TestDelegatesRolesUpdateWithConsistentSnapshotEnabled(t *testing.T) {
 	updaterConfig, err := loadUpdaterConfig()
 	assert.NoError(t, err)
 	updater := initUpdater(updaterConfig)
-
+	if updater == nil {
+		t.Fatal("updater is nil")
+	}
 	err = updater.Refresh()
 	assert.NoError(t, err)
 

--- a/testutils/simulator/repository_simulator_setup.go
+++ b/testutils/simulator/repository_simulator_setup.go
@@ -19,6 +19,7 @@ package simulator
 
 import (
 	"os"
+	"path/filepath"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -65,11 +66,11 @@ func InitMetadataDir() (*RepositorySimulator, string, string, error) {
 	if err != nil {
 		log.Fatal("failed to initialize environment: ", err)
 	}
-	metadataDir := LocalDir + metadataPath
+	metadataDir := filepath.Join(LocalDir, metadataPath)
 
 	sim := NewRepository()
 
-	f, err := os.Create(metadataDir + "/root.json")
+	f, err := os.Create(filepath.Join(metadataDir, "root.json"))
 	if err != nil {
 		log.Fatalf("failed to create root: %v", err)
 	}
@@ -78,13 +79,13 @@ func InitMetadataDir() (*RepositorySimulator, string, string, error) {
 	if err != nil {
 		log.Debugf("repository simulator setup: failed to write signed roots: %v", err)
 	}
-	targetsDir := LocalDir + targetsPath
+	targetsDir := filepath.Join(LocalDir, targetsPath)
 	sim.LocalDir = LocalDir
 	return sim, metadataDir, targetsDir, err
 }
 
 func GetRootBytes(localMetadataDir string) ([]byte, error) {
-	return os.ReadFile(localMetadataDir + "/root.json")
+	return os.ReadFile(filepath.Join(localMetadataDir, "root.json"))
 }
 
 func RepositoryCleanup(tmpDir string) {

--- a/testutils/testutils/setup.go
+++ b/testutils/testutils/setup.go
@@ -39,7 +39,7 @@ func SetupTestDirs(repoPath string, targetsPath string, keystorePath string) err
 		return fmt.Errorf("failed to create temporary directory: %w", err)
 	}
 
-	RepoDir = fmt.Sprintf("%s/repository_data/repository", TempDir)
+	RepoDir = filepath.Join(TempDir, "repository_data", "repository")
 	absPath, err := filepath.Abs(repoPath)
 	if err != nil {
 		return fmt.Errorf("failed to get absolute path: %w", err)
@@ -49,7 +49,7 @@ func SetupTestDirs(repoPath string, targetsPath string, keystorePath string) err
 		return fmt.Errorf("failed to copy metadata to %s: %w", RepoDir, err)
 	}
 
-	TargetsDir = fmt.Sprintf("%s/repository_data/repository/targets", TempDir)
+	TargetsDir = filepath.Join(TempDir, "repository_data", "repository", "targets")
 	targetsAbsPath, err := filepath.Abs(targetsPath)
 	if err != nil {
 		return fmt.Errorf("failed to get absolute targets path: %w", err)
@@ -59,7 +59,7 @@ func SetupTestDirs(repoPath string, targetsPath string, keystorePath string) err
 		return fmt.Errorf("failed to copy metadata to %s: %w", RepoDir, err)
 	}
 
-	KeystoreDir = fmt.Sprintf("%s/keystore", TempDir)
+	KeystoreDir = filepath.Join(TempDir, "keystore")
 	err = os.Mkdir(KeystoreDir, 0750)
 	if err != nil {
 		return fmt.Errorf("failed to create keystore dir %s: %w", KeystoreDir, err)
@@ -86,11 +86,11 @@ func Copy(fromPath string, toPath string) error {
 		return fmt.Errorf("failed to read path %s: %w", fromPath, err)
 	}
 	for _, file := range files {
-		data, err := os.ReadFile(fmt.Sprintf("%s/%s", fromPath, file.Name()))
+		data, err := os.ReadFile(filepath.Join(fromPath, file.Name()))
 		if err != nil {
 			return fmt.Errorf("failed to read file %s: %w", file.Name(), err)
 		}
-		filePath := fmt.Sprintf("%s/%s", toPath, file.Name())
+		filePath := filepath.Join(toPath, file.Name())
 		err = os.WriteFile(filePath, data, 0750)
 		if err != nil {
 			return fmt.Errorf("failed to write file %s: %w", filePath, err)


### PR DESCRIPTION
Since windows tests were disabled, it looks like we've drifted a bit and introduced a few issues preventing the tests from passing and from the project working on windows:

* use of unix path separators throughout
* tests relying on line endings, and Git checkouts being different for windows/linux
* renaming of files between drives on windows on GitHub Actions
* renaming of open files (not allowed on windows)

Moved from https://github.com/rdimitrov/go-tuf-metadata/pull/98

*EDIT*
* Maybe merge this one first so that this PR can be tested properly: https://github.com/theupdateframework/go-tuf/pull/587