### PR TITLE
Do not pin to minor Go versions in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/theupdateframework/go-tuf/v2
 
-go 1.21.5
+go 1.21
 
 require (
 	github.com/go-logr/stdr v1.2.2


### PR DESCRIPTION
I believe we bumped this because of a scanning tool check that was quite annoying and insisted on upgrading the minor version.

In any case, I think it's better to not enforce other users of the library pin their minor version too just because of us. 