### PR TITLE
Enable macos and windows runners for examples.yml and tests.yml

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false # Keep running if one leg fails.
       matrix:
-        os: [ubuntu-latest] # , macos-latest, windows-latest] Enable later so we don't waste github actions resources
+        os: [ubuntu-latest, macos-latest, windows-latest]
         go-version: ${{ fromJSON(needs.get-go-versions.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
     needs: get-go-versions
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false # Keep running if one leg fails.
       matrix:
-        os: [ubuntu-latest] # , macos-latest, windows-latest] Enable later so we don't waste github actions resources
+        os: [ubuntu-latest, macos-latest, windows-latest]
         go-version: ${{ fromJSON(needs.get-go-versions.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
     needs: get-go-versions
@@ -63,7 +63,7 @@ jobs:
     strategy:
       fail-fast: false # Keep running if one leg fails.
       matrix:
-        os: [ubuntu-latest] # , macos-latest, windows-latest] Enable later so we don't waste github actions resources
+        os: [ubuntu-latest, macos-latest, windows-latest]
         go-version: ${{ fromJSON(needs.get-go-versions.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
     needs: get-go-versions
@@ -79,7 +79,7 @@ jobs:
     strategy:
       fail-fast: false # Keep running if one leg fails.
       matrix:
-        os: [ubuntu-latest] # , macos-latest, windows-latest] Enable later so we don't waste github actions resources
+        os: [ubuntu-latest, macos-latest, windows-latest]
         go-version: ${{ fromJSON(needs.get-go-versions.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
     needs: get-go-versions
@@ -95,7 +95,7 @@ jobs:
     strategy:
       fail-fast: false # Keep running if one leg fails.
       matrix:
-        os: [ubuntu-latest] # , macos-latest, windows-latest] Enable later so we don't waste github actions resources
+        os: [ubuntu-latest, macos-latest, windows-latest]
         go-version: ${{ fromJSON(needs.get-go-versions.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
     needs: get-go-versions

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false # Keep running if one leg fails.
       matrix:
-        os: [ubuntu-latest, windows-latest] # , ] Enable later so we don't waste github actions resources
+        os: [ubuntu-latest, macos-latest, windows-latest]
         go-version: ${{ fromJSON(needs.get-go-versions.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
     needs: get-go-versions

--- a/metadata/fetcher/fetcher.go
+++ b/metadata/fetcher/fetcher.go
@@ -56,7 +56,7 @@ func (d *DefaultFetcher) DownloadFile(urlPath string, maxLength int64, timeout t
 	}
 	defer res.Body.Close()
 	// Handle HTTP status codes.
-	if res.StatusCode == http.StatusNotFound || res.StatusCode == http.StatusForbidden || res.StatusCode != http.StatusOK {
+	if res.StatusCode != http.StatusOK {
 		return nil, &metadata.ErrDownloadHTTP{StatusCode: res.StatusCode, URL: urlPath}
 	}
 	var length int64


### PR DESCRIPTION
The following PR enables both `macos-latest` and `windows-latest` runner environments for the actions running the tests and the examples.