### PR TITLE
Do not run CI for all Go versions and use caching

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f
         with:
           go-version-file: 'go.mod'
-          cache: false
+          cache: true
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@74483a38d39275f33fcff5f35b679b5ca4a26a99

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -16,94 +16,86 @@
 # SPDX-License-Identifier: Apache-2.0
 on:
   workflow_call:
-name: Examples # not exactly right to test functionality in such a way but it does act as a set of end to end test cases for the time being, nevertheless should be updated
+# Not exactly right to test functionality in such a way, but it does act as a set of end-to-end test cases for the time
+# being, nevertheless should be updated
+name: Examples
 jobs:
-  get-go-versions:
-    name: Collect available Go versions
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.versions.outputs.matrix }}
-    steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
-      - uses: arnested/go-version-action@b556f8d91b644164318c709d28b9083eaf0c064d
-        id: versions
   client:
     strategy:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go-version: ${{ fromJSON(needs.get-go-versions.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
-    needs: get-go-versions
     steps:
       - name: Checkout code
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
-      - name: Setup - Go ${{ matrix.go-version }}
+      - name: Setup - Go
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version-file: 'go.mod'
+          cache: true
       - run: make example-client
+
   repository:
     strategy:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go-version: ${{ fromJSON(needs.get-go-versions.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
-    needs: get-go-versions
     steps:
       - name: Checkout code
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
-      - name: Setup - Go ${{ matrix.go-version }}
+      - name: Setup - Go
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version-file: 'go.mod'
+          cache: true
       - run: make example-repository
+
   multirepo:
     strategy:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go-version: ${{ fromJSON(needs.get-go-versions.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
-    needs: get-go-versions
     steps:
       - name: Checkout code
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
-      - name: Setup - Go ${{ matrix.go-version }}
+      - name: Setup - Go
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version-file: 'go.mod'
+          cache: true
       - run: make example-multirepo
+
   tuf-client-cli:
     strategy:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go-version: ${{ fromJSON(needs.get-go-versions.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
-    needs: get-go-versions
     steps:
       - name: Checkout code
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
-      - name: Setup - Go ${{ matrix.go-version }}
+      - name: Setup - Go
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version-file: 'go.mod'
+          cache: true
       - run: make example-tuf-client-cli
+
   root-signing:
     strategy:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go-version: ${{ fromJSON(needs.get-go-versions.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
-    needs: get-go-versions
     steps:
       - name: Checkout code
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
-      - name: Setup - Go ${{ matrix.go-version }}
+      - name: Setup - Go
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version-file: 'go.mod'
+          cache: true
       - run: make example-root-signing

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -31,12 +31,16 @@ jobs:
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
-      - uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f
+      - name: Checkout code
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+
+      - name: Setup - Go
+        uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f
         with:
           go-version-file: 'go.mod'
-          cache: false
-      - name: golangci-lint
+          cache: true
+
+      - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
           # Require: The version of golangci-lint to use.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,24 +18,13 @@ on:
   workflow_call:
 name: Tests
 jobs:
-  get-go-versions:
-    name: Collect available Go versions
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.versions.outputs.matrix }}
-    steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
-      - uses: arnested/go-version-action@b556f8d91b644164318c709d28b9083eaf0c064d
-        id: versions
   run:
     name: Run
     strategy:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go-version: ${{ fromJSON(needs.get-go-versions.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
-    needs: get-go-versions
     steps:
       - name: Set git to use LF
         run: git config --global core.autocrlf false
@@ -43,15 +32,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
 
-      - name: Setup - Go ${{ matrix.go-version }}
+      - name: Setup - Go
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version-file: 'go.mod'
+          cache: true
 
       - name: Run tests
         run: go test -race -covermode=atomic -coverpkg=./metadata/... -coverprofile=coverage.out ./...
 
       - name: Send coverage
         uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
-        with:
-          flags: Go-${{ matrix.go-version }}


### PR DESCRIPTION
The following PR:
* Removes the tests we were running against all available Go versions above the one we are using in the go.mod file. This sounded useful, but it caused more CI failures than it helps.
* Sets the cache: true for most go actions