### PR TITLE
Use filepath.Join when combining filesystem components

### DIFF
--- a/metadata/updater/updater.go
+++ b/metadata/updater/updater.go
@@ -237,11 +237,9 @@ func (update *Updater) DownloadTarget(targetFile *metadata.TargetFiles, filePath
 		dirName, baseName, ok := strings.Cut(targetFilePath, "/")
 		if !ok {
 			// <hash>.<target-name>
-			targetFilePath = fmt.Sprintf("%s.%s", hashes, dirName)
-			targetRemotePath = targetFilePath
+			targetRemotePath = fmt.Sprintf("%s.%s", hashes, dirName)
 		} else {
 			// <dir-prefix>/<hash>.<target-name>
-			targetFilePath = filepath.Join(dirName, fmt.Sprintf("%s.%s", hashes, baseName))
 			targetRemotePath = fmt.Sprintf("%s/%s.%s", dirName, hashes, baseName)
 		}
 	}

--- a/metadata/updater/updater.go
+++ b/metadata/updater/updater.go
@@ -225,6 +225,7 @@ func (update *Updater) DownloadTarget(targetFile *metadata.TargetFiles, filePath
 	}
 
 	targetFilePath := targetFile.Path
+	targetRemotePath := targetFilePath
 	consistentSnapshot := update.trusted.Root.Signed.ConsistentSnapshot
 	if consistentSnapshot && update.cfg.PrefixTargetsWithHash {
 		hashes := ""
@@ -237,12 +238,14 @@ func (update *Updater) DownloadTarget(targetFile *metadata.TargetFiles, filePath
 		if !ok {
 			// <hash>.<target-name>
 			targetFilePath = fmt.Sprintf("%s.%s", hashes, dirName)
+			targetRemotePath = targetFilePath
 		} else {
 			// <dir-prefix>/<hash>.<target-name>
 			targetFilePath = filepath.Join(dirName, fmt.Sprintf("%s.%s", hashes, baseName))
+			targetRemotePath = fmt.Sprintf("%s/%s.%s", dirName, hashes, baseName)
 		}
 	}
-	fullURL := fmt.Sprintf("%s%s", targetBaseURL, targetFilePath)
+	fullURL := fmt.Sprintf("%s%s", targetBaseURL, targetRemotePath)
 	data, err := update.cfg.Fetcher.DownloadFile(fullURL, targetFile.Length, time.Second*15)
 	if err != nil {
 		return "", nil, err

--- a/metadata/updater/updater.go
+++ b/metadata/updater/updater.go
@@ -251,6 +251,7 @@ func (update *Updater) DownloadTarget(targetFile *metadata.TargetFiles, filePath
 	if err != nil {
 		return "", nil, err
 	}
+
 	// do not persist the target file if cache is disabled
 	if !update.cfg.DisableLocalCache {
 		err = os.WriteFile(filePath, data, 0644)

--- a/metadata/updater/updater.go
+++ b/metadata/updater/updater.go
@@ -223,6 +223,7 @@ func (update *Updater) DownloadTarget(targetFile *metadata.TargetFiles, filePath
 	} else {
 		targetBaseURL = ensureTrailingSlash(targetBaseURL)
 	}
+
 	targetFilePath := targetFile.Path
 	consistentSnapshot := update.trusted.Root.Signed.ConsistentSnapshot
 	if consistentSnapshot && update.cfg.PrefixTargetsWithHash {
@@ -250,7 +251,6 @@ func (update *Updater) DownloadTarget(targetFile *metadata.TargetFiles, filePath
 	if err != nil {
 		return "", nil, err
 	}
-
 	// do not persist the target file if cache is disabled
 	if !update.cfg.DisableLocalCache {
 		err = os.WriteFile(filePath, data, 0644)
@@ -674,7 +674,7 @@ func (update *Updater) generateTargetFilePath(tf *metadata.TargetFiles) (string,
 		return "", &metadata.ErrValue{Msg: "LocalTargetsDir must be set if filepath is not given"}
 	}
 	// Use URL encoded target path as filename
-	return url.JoinPath(update.cfg.LocalTargetsDir, url.QueryEscape(tf.Path))
+	return filepath.Join(update.cfg.LocalTargetsDir, url.QueryEscape(tf.Path)), nil
 }
 
 // loadLocalMetadata reads a local <roleName>.json file and returns its bytes


### PR DESCRIPTION
Partly fixes https://github.com/theupdateframework/go-tuf/issues/605

The `example-root-signing` test should now work on Windows.