### PR TITLE
Always use forward slash when splitting target names

### DIFF
--- a/examples/multirepo/client/client_example.go
+++ b/examples/multirepo/client/client_example.go
@@ -155,7 +155,8 @@ func BootstrapTUF() ([]byte, map[string][]byte, error) {
 		if name == "map.json" {
 			mapBytes = bytes
 		} else {
-			repositoryName := strings.Split(name, string(os.PathSeparator))
+			// Target names uses forwardslash even on Windows
+			repositoryName := strings.Split(name, "/")
 			trustedRoots[repositoryName[0]] = bytes
 		}
 		log.Info("Successfully downloaded target", "target", name, "path", path)


### PR DESCRIPTION
Even when running on Windows, the targets in the root uses forward slash.

Closes https://github.com/theupdateframework/go-tuf/issues/605