### PR TITLE
Silence govulncheck

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -24,6 +24,7 @@ jobs:
     steps:
       - id: govulncheck
         uses: golang/govulncheck-action@3a32958c2706f7048305d5a2e53633d7e37e97d0
+        continue-on-error: true
         with:
           go-version-file: 'go.mod'
           go-package: ./...


### PR DESCRIPTION
As we only pin the minor version and not the patch version of Go (as most projects do), we can't guarantee the CI to use a toolchain version which has security fixes govulncheck would otherwise complain about.

EDIT: We keep the go.mod as is but modified the CI pipeline as outlined below.