### PR TITLE
repository_simulator_setup.go: Use filepath.Join() instead of concatenation

### DIFF
--- a/internal/testutils/simulator/repository_simulator_setup.go
+++ b/internal/testutils/simulator/repository_simulator_setup.go
@@ -48,11 +48,11 @@ func InitLocalEnv() error {
 		os.Exit(1)
 	}
 
-	if err = os.Mkdir(tmpDir+metadataPath, 0750); err != nil {
+	if err = os.Mkdir(filepath.Join(tmpDir,metadataPath), 0750); err != nil {
 		slog.Error("Repository simulator: failed to create dir", "err", err)
 	}
 
-	if err = os.Mkdir(tmpDir+targetsPath, 0750); err != nil {
+	if err = os.Mkdir(filepath.Join(tmpDir,targetsPath), 0750); err != nil {
 		slog.Error("Repository simulator: failed to create dir", "err", err)
 	}
 


### PR DESCRIPTION
Per title.

e.g. `tmpDir + metadataPath` is just weird and fragile, use `filepath.Join()`, its what its there for.  :wink: