### PR TITLE
Remove nil error from being printed in "persist metadata" error message

### DIFF
--- a/metadata/updater/updater.go
+++ b/metadata/updater/updater.go
@@ -652,7 +652,7 @@ func (update *Updater) persistMetadata(roleName string, data []byte) error {
 		return err
 	}
 	if string(read) != string(data) {
-		return fmt.Errorf("failed to persist metadata: %w", err)
+		return fmt.Errorf("failed to persist metadata")
 	}
 	return nil
 }


### PR DESCRIPTION
When go-tuf is unable to persist the TUF metadata, I receive the error "failed to persist metadata: %!w(\<nil\>)". Because the code already checks if the error is not nil and returns it if not on [line 651](https://github.com/theupdateframework/go-tuf/blob/b2e024ad4752cc0c4a4e376460b21deb79e40ded/metadata/updater/updater.go#L651), the "failed to persist" error message will always try to print a nil error.