### PR TITLE
export API to set RefTime of Updater

### DIFF
--- a/metadata/updater/updater.go
+++ b/metadata/updater/updater.go
@@ -662,7 +662,7 @@ func (update *Updater) GetTrustedMetadataSet() trustedmetadata.TrustedMetadata {
 	return *update.trusted
 }
 
-func (update *Updater) SetRefTime(t time.Time) {
+func (update *Updater) UnsafeSetRefTime(t time.Time) {
 	update.trusted.RefTime = t
 }
 

--- a/metadata/updater/updater.go
+++ b/metadata/updater/updater.go
@@ -662,6 +662,9 @@ func (update *Updater) GetTrustedMetadataSet() trustedmetadata.TrustedMetadata {
 	return *update.trusted
 }
 
+// Sets the reference time that the updater uses.
+// This should only be done in tests.
+// UnsafeSetRefTime is useful when testing time-related behavior in go-tuf.
 func (update *Updater) UnsafeSetRefTime(t time.Time) {
 	update.trusted.RefTime = t
 }

--- a/metadata/updater/updater.go
+++ b/metadata/updater/updater.go
@@ -662,6 +662,10 @@ func (update *Updater) GetTrustedMetadataSet() trustedmetadata.TrustedMetadata {
 	return *update.trusted
 }
 
+func (update *Updater) SetRefTime(t time.Time) {
+	update.trusted.RefTime = t
+}
+
 func IsWindowsPath(path string) bool {
 	match, _ := regexp.MatchString(`^[a-zA-Z]:\\`, path)
 	return match

--- a/metadata/updater/updater.go
+++ b/metadata/updater/updater.go
@@ -662,9 +662,9 @@ func (update *Updater) GetTrustedMetadataSet() trustedmetadata.TrustedMetadata {
 	return *update.trusted
 }
 
-// Sets the reference time that the updater uses.
+// UnsafeSetRefTime sets the reference time that the updater uses.
 // This should only be done in tests.
-// UnsafeSetRefTime is useful when testing time-related behavior in go-tuf.
+// Using this function is useful when testing time-related behavior in go-tuf.
 func (update *Updater) UnsafeSetRefTime(t time.Time) {
 	update.trusted.RefTime = t
 }

--- a/metadata/updater/updater_top_level_update_test.go
+++ b/metadata/updater/updater_top_level_update_test.go
@@ -98,7 +98,7 @@ func runRefresh(updaterConfig *config.UpdaterConfig, moveInTime time.Time) (Upda
 	}
 
 	if moveInTime != time.Now() {
-		updater.trusted.RefTime = moveInTime
+		updater.SetRefTime(moveInTime)
 	}
 
 	return *updater, updater.Refresh()

--- a/metadata/updater/updater_top_level_update_test.go
+++ b/metadata/updater/updater_top_level_update_test.go
@@ -98,7 +98,7 @@ func runRefresh(updaterConfig *config.UpdaterConfig, moveInTime time.Time) (Upda
 	}
 
 	if moveInTime != time.Now() {
-		updater.SetRefTime(moveInTime)
+		updater.UnsafeSetRefTime(moveInTime)
 	}
 
 	return *updater, updater.Refresh()


### PR DESCRIPTION
This PR exports an API to set the `RefTime` of the trusted metadata of an `Updater`. This is useful for testing time-related cases in the client outside of go-tufs own repository.