### PR TITLE
Increase the default value for MaxRootRotations

### DIFF
--- a/metadata/config/config.go
+++ b/metadata/config/config.go
@@ -57,7 +57,7 @@ func New(remoteURL string, rootBytes []byte) (*UpdaterConfig, error) {
 
 	return &UpdaterConfig{
 		// TUF configuration
-		MaxRootRotations:   32,
+		MaxRootRotations:   256,
 		MaxDelegations:     32,
 		RootMaxLength:      512000,  // bytes
 		TimestampMaxLength: 16384,   // bytes

--- a/metadata/config/config_test.go
+++ b/metadata/config/config_test.go
@@ -43,7 +43,7 @@ func TestNewUpdaterConfig(t *testing.T) {
 			remoteURL: "somepath",
 			rootBytes: []byte("somerootbytes"),
 			config: &UpdaterConfig{
-				MaxRootRotations:      32,
+				MaxRootRotations:      256,
 				MaxDelegations:        32,
 				RootMaxLength:         512000,
 				TimestampMaxLength:    16384,


### PR DESCRIPTION
The default value of 32 is quite small, it may break certain clients that are trying to do complete tuf refresh on a large TUF repo.

Closes #644 