### PR TITLE
Error in case the delegated role is missing from the snapshot

### DIFF
--- a/metadata/updater/updater.go
+++ b/metadata/updater/updater.go
@@ -443,8 +443,11 @@ func (update *Updater) loadTargets(roleName, parentName string) (*metadata.Metad
 	if update.trusted.Snapshot == nil {
 		return nil, fmt.Errorf("trusted snapshot not set")
 	}
-	// extract the targets meta from the trusted snapshot metadata
-	metaInfo := update.trusted.Snapshot.Signed.Meta[fmt.Sprintf("%s.json", roleName)]
+	// extract the targets' meta from the trusted snapshot metadata
+	metaInfo, ok := update.trusted.Snapshot.Signed.Meta[fmt.Sprintf("%s.json", roleName)]
+	if !ok {
+		return nil, fmt.Errorf("role %s not found in snapshot", roleName)
+	}
 	// extract the length of the target metadata to be downloaded
 	length := metaInfo.Length
 	if length == 0 {


### PR DESCRIPTION
The following PR fixes the issue where go-tuf will SIGSEGV if a top-level target delegates to another role but that role is not listed in the snapshot metadata.

This is highly unlikely to happen because the attacker must have the ability to create a delegation to a new role in the repository and must be able to prevent this delegation from being included in snapshot metadata in the repository. This implies a significant compromise of a repository. If these requirements are met and client tries to download anything delegated to the new role, it will segfault. In any case it's worth fixing it.

Thanks to @jku for reporting this issue! 👏 