### PR TITLE
Pre-emptive file writing bug fixes in update.go

### DIFF
--- a/metadata/updater/copy.go
+++ b/metadata/updater/copy.go
@@ -1,0 +1,53 @@
+package updater
+
+import (
+	"io"
+	"os"
+)
+
+// CrossMoveFile is a verbose implementation of os.Rename() that enables cross-filesystem moves
+func crossMoveFile(source *os.File, dest string, removeSource bool, overwrite bool) error {
+	var flag int
+	// Set flag according to overwrite preference
+	if overwrite {
+		flag = os.O_RDWR | os.O_CREATE | os.O_TRUNC
+	} else {
+		flag = os.O_RDWR | os.O_CREATE | os.O_EXCL
+	}
+	// Open the destination
+	destFil, err := os.OpenFile(dest, flag, 0644)
+	if err != nil {
+		return err
+	}
+	// Copy !
+	_, err = io.Copy(destFil, source)
+	if err != nil {
+		return err
+	}
+	// Belt and braces
+	err = destFil.Sync()
+	if err != nil {
+		return err
+	}
+	// Remove source if requested
+	if removeSource {
+		// Remember the name
+		sourceName := source.Name()
+		// Close before removing !
+		err = source.Close()
+		if err != nil {
+			return err
+		}
+		err = os.Remove(sourceName)
+		if err != nil {
+			return err
+		}
+	} else {
+		err = source.Close()
+		if err != nil {
+			return err
+		}
+	}
+	// We are done
+	return destFil.Close()
+}

--- a/metadata/updater/copy.go
+++ b/metadata/updater/copy.go
@@ -14,6 +14,11 @@ func crossMoveFile(source *os.File, dest string, removeSource bool, overwrite bo
 	} else {
 		flag = os.O_RDWR | os.O_CREATE | os.O_EXCL
 	}
+	// Make sure we are at the start of the source
+	_, err := source.Seek(0, 0)
+	if err != nil {
+		return err
+	}
 	// Open the destination
 	destFil, err := os.OpenFile(dest, flag, 0644)
 	if err != nil {

--- a/metadata/updater/updater.go
+++ b/metadata/updater/updater.go
@@ -598,7 +598,7 @@ func (update *Updater) persistMetadata(roleName string, data []byte) error {
 	}
 	defer file.Close()
 	// write the data content to the temporary file
-	err = os.WriteFile(file.Name(), data, 0644)
+	_, err = file.Write(data)
 	if err != nil {
 		// delete the temporary file if there was an error while writing
 		errRemove := os.Remove(file.Name())
@@ -608,23 +608,12 @@ func (update *Updater) persistMetadata(roleName string, data []byte) error {
 		return err
 	}
 
-	// can't move/rename an open file on windows, so close it first
-	err = file.Close()
-	if err != nil {
-		return err
-	}
 	// if all okay, rename the temporary file to the desired one
-	err = os.Rename(file.Name(), fileName)
+	err = crossMoveFile(file, fileName, true, true)
 	if err != nil {
 		return err
 	}
-	read, err := os.ReadFile(fileName)
-	if err != nil {
-		return err
-	}
-	if string(read) != string(data) {
-		return fmt.Errorf("failed to persist metadata")
-	}
+	
 	return nil
 }
 


### PR DESCRIPTION
Suggestion for a couple of bug fixes for you to consider.....

1. For some unknown reason you were calling `os.WriteFile(file.Name(), data, 0644)` when `file` was already open ?  This was therefore replaced with `_, err = file.Write(data)`.
2. Suggested proactive fix for a subtle edge-case bug ... `os.Rename()` does not work accross mount-points[1], therefore:

   1. added mount-point safe copy in `copy.go`
   2. this has the added bonus of making your write check redundant, so removed that surplus code

I think it should be fine, but clearly you'll want to double check...  :wink:


[1] https://groups.google.com/g/golang-dev/c/5w7Jmg_iCJQ/m/hB_8mfV6pBUJ