### PR TITLE
updater.go: replace os.WriteFile with file.Write()

### DIFF
--- a/metadata/updater/updater.go
+++ b/metadata/updater/updater.go
@@ -596,7 +596,6 @@ func (update *Updater) persistMetadata(roleName string, data []byte) error {
 	if err != nil {
 		return err
 	}
-	defer file.Close()
 	// change the file permissions to our desired permissions
 	err = file.Chmod(0644)
 	if err != nil {


### PR DESCRIPTION
Ref https://github.com/theupdateframework/go-tuf/issues/667

I also added an explicit `file.Close()` on the error conditions here because otherwise `defer file.Close()` would be called after the `file.Remove()`, IIRC Windows errors if you attempt to remove an open file.