### PR TITLE
Remove readFile() and reverseSlice() in favour of stdlib

### DIFF
--- a/examples/cli/tuf-client/cmd/init.go
+++ b/examples/cli/tuf-client/cmd/init.go
@@ -81,7 +81,7 @@ func InitializeCmd() error {
 	}
 
 	// read the content of root.json
-	rootBytes, err := ReadFile(rootPath)
+	rootBytes, err := os.ReadFile(rootPath)
 	if err != nil {
 		return err
 	}

--- a/examples/cli/tuf-client/cmd/root.go
+++ b/examples/cli/tuf-client/cmd/root.go
@@ -18,7 +18,6 @@
 package cmd
 
 import (
-	"io"
 	"os"
 
 	"github.com/spf13/cobra"

--- a/examples/cli/tuf-client/cmd/root.go
+++ b/examples/cli/tuf-client/cmd/root.go
@@ -57,17 +57,3 @@ func Execute() {
 		os.Exit(1)
 	}
 }
-
-// ReadFile reads the content of a file and return its bytes
-func ReadFile(name string) ([]byte, error) {
-	in, err := os.Open(name)
-	if err != nil {
-		return nil, err
-	}
-	defer in.Close()
-	data, err := io.ReadAll(in)
-	if err != nil {
-		return nil, err
-	}
-	return data, nil
-}

--- a/examples/cli/tuf/cmd/root.go
+++ b/examples/cli/tuf/cmd/root.go
@@ -18,7 +18,6 @@
 package cmd
 
 import (
-	"io"
 	"os"
 
 	"github.com/spf13/cobra"

--- a/examples/cli/tuf/cmd/root.go
+++ b/examples/cli/tuf/cmd/root.go
@@ -42,17 +42,3 @@ func Execute() {
 		os.Exit(1)
 	}
 }
-
-// ReadFile reads the content of a file and return its bytes
-func ReadFile(name string) ([]byte, error) {
-	in, err := os.Open(name)
-	if err != nil {
-		return nil, err
-	}
-	defer in.Close()
-	data, err := io.ReadAll(in)
-	if err != nil {
-		return nil, err
-	}
-	return data, nil
-}

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -161,12 +161,7 @@ func MetaFile(version int64) *MetaFiles {
 
 // FromFile load metadata from file
 func (meta *Metadata[T]) FromFile(name string) (*Metadata[T], error) {
-	in, err := os.Open(name)
-	if err != nil {
-		return nil, err
-	}
-	defer in.Close()
-	data, err := io.ReadAll(in)
+	data, err := os.ReadFile(name)
 	if err != nil {
 		return nil, err
 	}
@@ -474,14 +469,8 @@ func (source *TargetFiles) Equal(expected TargetFiles) bool {
 // FromFile generate TargetFiles from file
 func (t *TargetFiles) FromFile(localPath string, hashes ...string) (*TargetFiles, error) {
 	log.Info("Generating target file from file", "path", localPath)
-	// open file
-	in, err := os.Open(localPath)
-	if err != nil {
-		return nil, err
-	}
-	defer in.Close()
 	// read file
-	data, err := io.ReadAll(in)
+	data, err := os.ReadFile(localPath)
 	if err != nil {
 		return nil, err
 	}

--- a/metadata/updater/updater.go
+++ b/metadata/updater/updater.go
@@ -21,7 +21,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -283,7 +282,7 @@ func (update *Updater) FindCachedTarget(targetFile *metadata.TargetFiles, filePa
 		targetFilePath = filePath
 	}
 	// get file content
-	data, err := readFile(targetFilePath)
+	data, err := os.ReadFile(targetFilePath)
 	if err != nil {
 		// do not want to return err, instead we say that there's no cached target available
 		return "", nil, nil
@@ -663,7 +662,7 @@ func (update *Updater) generateTargetFilePath(tf *metadata.TargetFiles) (string,
 
 // loadLocalMetadata reads a local <roleName>.json file and returns its bytes
 func (update *Updater) loadLocalMetadata(roleName string) ([]byte, error) {
-	return readFile(fmt.Sprintf("%s.json", roleName))
+	return os.ReadFile(fmt.Sprintf("%s.json", roleName))
 }
 
 // GetTopLevelTargets returns the top-level target files
@@ -708,18 +707,4 @@ func reverseSlice[S ~[]E, E any](s S) {
 	for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {
 		s[i], s[j] = s[j], s[i]
 	}
-}
-
-// readFile reads the content of a file and return its bytes
-func readFile(name string) ([]byte, error) {
-	in, err := os.Open(name)
-	if err != nil {
-		return nil, err
-	}
-	defer in.Close()
-	data, err := io.ReadAll(in)
-	if err != nil {
-		return nil, err
-	}
-	return data, nil
 }

--- a/metadata/updater/updater.go
+++ b/metadata/updater/updater.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -568,7 +569,7 @@ func (update *Updater) preOrderDepthFirstWalk(targetFilePath string) (*metadata.
 			// push childRolesToVisit in reverse order of appearance
 			// onto delegationsToVisit. Roles are popped from the end of
 			// the list
-			reverseSlice(childRolesToVisit)
+			slices.Reverse(childRolesToVisit)
 			delegationsToVisit = append(delegationsToVisit, childRolesToVisit...)
 		}
 	}
@@ -700,11 +701,4 @@ func ensureTrailingSlash(url string) string {
 		return url
 	}
 	return url + "/"
-}
-
-// reverseSlice reverses the elements in a generic type of slice
-func reverseSlice[S ~[]E, E any](s S) {
-	for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {
-		s[i], s[j] = s[j], s[i]
-	}
 }


### PR DESCRIPTION
propose removing `readFile()` from `updater.go` as it appears to essentially be a re-implementation of stdlib's `os.ReadFile`

Also found a "hidden" re-implementation of `os.ReadFile` in metadata.go, so changed that to `os.ReadFile` too.

Also found the re-implementation of `os.Readfile` in `cli/tuf/cmd/root.go`, so changed that to `os.ReadFile` too.

Also found a re-implementation of `os.ReadFile` in `cli/tuf-client/cmd/root.go` where it appears completely unused ?

Also `reverseSlice()` in `metadata/updater/updater.go` seems to be a reimplementation of stdlib's `slices.Reverse()` so removed that too.

Phew... I think that's all of them. 😆 