### PR TITLE
Set a default HTTP client for DefaultFetcher in DownloadFile method if none is set

### DIFF
--- a/metadata/fetcher/fetcher.go
+++ b/metadata/fetcher/fetcher.go
@@ -70,6 +70,11 @@ func (d *DefaultFetcher) DownloadFile(urlPath string, maxLength int64, _ time.Du
 		req.Header.Set("User-Agent", d.httpUserAgent)
 	}
 
+	// For backwards compatibility, if the client is nil, use the default client.
+	if d.client == nil {
+		d.client = http.DefaultClient
+	}
+
 	operation := func() ([]byte, error) {
 		// Execute the request.
 		res, err := d.client.Do(req)

--- a/metadata/fetcher/fetcher_test.go
+++ b/metadata/fetcher/fetcher_test.go
@@ -170,3 +170,9 @@ func TestDownloadFile_Retry(t *testing.T) {
 		})
 	}
 }
+
+func TestDownloadFile_NoHTTPClientSet(t *testing.T) {
+	fetcher := DefaultFetcher{}
+	_, err := fetcher.DownloadFile("https://jku.github.io/tuf-demo/metadata/1.root.json", 512000, 0)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
If someone instantiates a new DefaultFetcher directly with `DefaultFetcher{}` instead of with the new constructor , `DownloadFile` will fail because the `client` field has not been set. This pull request updates `DownloadFile` to check if the `client` field is `nil` and sets a default HTTP client if it is to avoid breaking current usage of `DefaultFetcher`.