### PR TITLE
fix: treat http 403 as an updater error

### DIFF
--- a/metadata/updater/updater.go
+++ b/metadata/updater/updater.go
@@ -491,11 +491,11 @@ func (update *Updater) loadRoot() error {
 			// downloading the root metadata failed for some reason
 			var tmpErr *metadata.ErrDownloadHTTP
 			if errors.As(err, &tmpErr) {
-				if tmpErr.StatusCode != http.StatusNotFound && tmpErr.StatusCode != http.StatusForbidden {
+				if tmpErr.StatusCode != http.StatusNotFound {
 					// unexpected HTTP status code
 					return err
 				}
-				// 404/403 means current root is newest available, so we can stop the loop and move forward
+				// 404 means current root is newest available, so we can stop the loop and move forward
 				break
 			}
 			// some other error ocurred


### PR DESCRIPTION
Previously 403 was handled like 404 in the updater stating that no new update is available but that behavior is deemed incorrect in most cases so go-tuf will divert from python-tuf's behavior. This resolves #673 