### PR TITLE
Update the config for govulncheck

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -24,9 +24,9 @@ jobs:
     steps:
       - id: govulncheck
         uses: golang/govulncheck-action@3a32958c2706f7048305d5a2e53633d7e37e97d0
-        continue-on-error: true
         with:
-          go-version-file: 'go.mod'
+          go-version-input: ''
+          go-version-file: go.mod
           go-package: ./...
 
   golangci:


### PR DESCRIPTION
The following updates the config for govulncheck. For some reason we had `continue-on-error: true` which was hiding some of the errors.
 