### PR TITLE
Decouple CI Go version from module minimum

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup - Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version-file: 'go.mod'
+          go-version: 'stable'
           cache: true
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup - Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version-file: 'go.mod'
+          go-version: 'stable'
           cache: true
 
       - run: make example-client
@@ -51,7 +51,7 @@ jobs:
       - name: Setup - Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version-file: 'go.mod'
+          go-version: 'stable'
           cache: true
 
       - run: make example-repository
@@ -69,7 +69,7 @@ jobs:
       - name: Setup - Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version-file: 'go.mod'
+          go-version: 'stable'
           cache: true
 
       - run: make example-multirepo
@@ -87,7 +87,7 @@ jobs:
       - name: Setup - Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version-file: 'go.mod'
+          go-version: 'stable'
           cache: true
 
       - run: make example-tuf-client-cli
@@ -105,7 +105,7 @@ jobs:
       - name: Setup - Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version-file: 'go.mod'
+          go-version: 'stable'
           cache: true
 
       - run: make example-root-signing

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -25,8 +25,7 @@ jobs:
       - id: govulncheck
         uses: golang/govulncheck-action@3a32958c2706f7048305d5a2e53633d7e37e97d0
         with:
-          go-version-input: ''
-          go-version-file: go.mod
+          go-version-input: 'stable'
           go-package: ./...
 
   golangci:
@@ -39,7 +38,7 @@ jobs:
       - name: Setup - Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version-file: 'go.mod'
+          go-version: 'stable'
           cache: true
 
       - name: Run golangci-lint

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -47,5 +47,5 @@ jobs:
           # Require: The version of golangci-lint to use.
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
           # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
-          version: v2.7.2
+          version: v2.11.4
           args: --timeout 5m --verbose

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,7 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        go-version: ['oldstable', 'stable']
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set git to use LF
@@ -35,7 +36,7 @@ jobs:
       - name: Setup - Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version-file: 'go.mod'
+          go-version: ${{ matrix.go-version }}
           cache: true
 
       - name: Run tests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/theupdateframework/go-tuf/v2
 
-go 1.25.5
+go 1.25.0
+
+toolchain go1.25.8
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/theupdateframework/go-tuf/v2
 
 go 1.25.0
 
-toolchain go1.25.8
-
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/go-logr/stdr v1.2.2


### PR DESCRIPTION
The following PR:
- Lower the go directive in go.mod to 1.25.0 (minimum version consumers need)
- Switch all CI workflows from go-version-file: 'go.mod' to go-version: 'stable'
- Add oldstable and stable Go version matrix to the test workflow for cross-version validation

This follows Go's recommended pattern for libraries: declare the minimum supported version in go.mod and let consumers control their own toolchain. No toolchain directive or .go-version file needed.

Alternative approach to #722