### PR TITLE
Fix threshold counting for duplicate public keys

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -24,6 +24,7 @@ import (
 	"crypto/rsa"
 	"crypto/sha256"
 	"crypto/sha512"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/hex"
@@ -246,6 +247,10 @@ func (meta *Metadata[T]) Sign(signer signature.Signer) (*Signature, error) {
 // threshold of keys for the delegated role delegatedRole
 func (meta *Metadata[T]) VerifyDelegate(delegatedRole string, delegatedMetadata any) error {
 	i := any(meta)
+	// keyed by SHA-256 of the PKIX-marshaled public key bytes, not by keyID,
+	// so two *Key records that resolve to the same underlying public key
+	// (e.g. registered under both "ecdsa" and "ecdsa-sha2-nistp256") count
+	// as a single threshold contribution.
 	signingKeys := map[string]bool{}
 	var keys map[string]*Key
 	var roleKeyIDs []string
@@ -316,6 +321,12 @@ func (meta *Metadata[T]) VerifyDelegate(delegatedRole string, delegatedMetadata 
 		if err != nil {
 			return err
 		}
+		pubBytes, err := x509.MarshalPKIXPublicKey(publicKey)
+		if err != nil {
+			return err
+		}
+		pubFingerprint := sha256.Sum256(pubBytes)
+		fingerprint := hex.EncodeToString(pubFingerprint[:])
 		// use corresponding hash function for key type
 		hash := crypto.Hash(0)
 		if key.Type != KeyTypeEd25519 {
@@ -398,8 +409,8 @@ func (meta *Metadata[T]) VerifyDelegate(delegatedRole string, delegatedMetadata 
 			// failed to verify the metadata with that key ID
 			log.Info("Failed to verify role with key ID", "role", delegatedRole, "ID", keyID)
 		} else {
-			// save the verified keyID only if verification passed
-			signingKeys[keyID] = true
+			// save the verified public-key fingerprint only if verification passed
+			signingKeys[fingerprint] = true
 			log.Info("Verified with key", "role", delegatedRole, "ID", keyID)
 		}
 	}

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -18,7 +18,13 @@
 package metadata
 
 import (
+	"bytes"
+	"crypto"
+	"crypto/ecdsa"
 	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/sha256"
 	"encoding/json"
 	"os"
@@ -26,6 +32,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/secure-systems-lab/go-securesystemslib/cjson"
+	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -660,6 +668,120 @@ func TestVerifyDelegateThreshold(t *testing.T) {
 	err = targets.VerifyDelegate("test", targets)
 	assert.ErrorIs(t, err, &ErrValue{})
 	assert.EqualError(t, err, "value error: insufficient threshold (0) configured for test")
+}
+
+// Regression: one ECDSA public key registered under both
+// KeyTypeECDSA_SHA2_P256 ("ecdsa") and KeyTypeECDSA_SHA2_P256_COMPAT
+// ("ecdsa-sha2-nistp256") must count as a single threshold contribution.
+// Canonical-JSON-based Key.ID() includes `keytype`, so the two records
+// produce distinct keyIDs from one PEM; a keyID-keyed threshold map would
+// accept a single private-key holder as satisfying threshold=2.
+func TestVerifyDelegateDuplicateKeyTypeECDSA(t *testing.T) {
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	assert.NoError(t, err)
+
+	// keyA is what KeyFromPublicKey produces: Type=KeyTypeECDSA_SHA2_P256.
+	keyA, err := KeyFromPublicKey(&privKey.PublicKey)
+	assert.NoError(t, err)
+	// keyB shares the same PEM under the COMPAT type string.
+	keyB := &Key{
+		Type:   KeyTypeECDSA_SHA2_P256_COMPAT,
+		Scheme: keyA.Scheme,
+		Value:  keyA.Value,
+	}
+
+	targets := Targets(fixedExpire)
+	payload, err := cjson.EncodeCanonical(targets.Signed)
+	assert.NoError(t, err)
+	signer, err := signature.LoadSignerVerifier(privKey, crypto.SHA256)
+	assert.NoError(t, err)
+	sigBytes, err := signer.SignMessage(bytes.NewReader(payload))
+	assert.NoError(t, err)
+
+	assertDuplicatePublicKeyCountsOnce(t, keyA, keyB, targets, sigBytes)
+}
+
+// Regression: even without an alternate keytype, duplicate Ed25519 key records
+// that resolve to the same public key must count as a single threshold
+// contribution.
+func TestVerifyDelegateDuplicatePublicKeyEd25519(t *testing.T) {
+	pubKey, privKey, err := ed25519.GenerateKey(rand.Reader)
+	assert.NoError(t, err)
+
+	keyA, err := KeyFromPublicKey(pubKey)
+	assert.NoError(t, err)
+	keyB := &Key{
+		Type:   keyA.Type,
+		Scheme: "ed25519-duplicate",
+		Value:  keyA.Value,
+	}
+
+	targets := Targets(fixedExpire)
+	payload, err := cjson.EncodeCanonical(targets.Signed)
+	assert.NoError(t, err)
+	signer, err := signature.LoadSignerVerifier(privKey, crypto.Hash(0))
+	assert.NoError(t, err)
+	sigBytes, err := signer.SignMessage(bytes.NewReader(payload))
+	assert.NoError(t, err)
+
+	assertDuplicatePublicKeyCountsOnce(t, keyA, keyB, targets, sigBytes)
+}
+
+// Regression: duplicate RSA key records that resolve to the same public key
+// must count as a single threshold contribution.
+func TestVerifyDelegateDuplicatePublicKeyRSA(t *testing.T) {
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	assert.NoError(t, err)
+
+	keyA, err := KeyFromPublicKey(&privKey.PublicKey)
+	assert.NoError(t, err)
+	keyB := &Key{
+		Type:   keyA.Type,
+		Scheme: "rsassa-pss-sha256-duplicate",
+		Value:  keyA.Value,
+	}
+
+	targets := Targets(fixedExpire)
+	payload, err := cjson.EncodeCanonical(targets.Signed)
+	assert.NoError(t, err)
+	signer, err := signature.LoadRSAPSSSignerVerifier(privKey, crypto.SHA256, nil)
+	assert.NoError(t, err)
+	sigBytes, err := signer.SignMessage(bytes.NewReader(payload))
+	assert.NoError(t, err)
+
+	assertDuplicatePublicKeyCountsOnce(t, keyA, keyB, targets, sigBytes)
+}
+
+func assertDuplicatePublicKeyCountsOnce(t *testing.T, keyA, keyB *Key, targets *Metadata[TargetsType], sigBytes []byte) {
+	t.Helper()
+
+	keyIDA, err := keyA.ID()
+	assert.NoError(t, err)
+	keyIDB, err := keyB.ID()
+	assert.NoError(t, err)
+	assert.NotEqual(t, keyIDA, keyIDB, "test must exercise two keyIDs for one public key")
+
+	targets.Signatures = []Signature{
+		{KeyID: keyIDA, Signature: sigBytes},
+		{KeyID: keyIDB, Signature: sigBytes},
+	}
+
+	root := Root(fixedExpire)
+	root.Signed.Keys[keyIDA] = keyA
+	root.Signed.Keys[keyIDB] = keyB
+	root.Signed.Roles[TARGETS] = &Role{
+		KeyIDs:    []string{keyIDA, keyIDB},
+		Threshold: 2,
+	}
+
+	err = root.VerifyDelegate(TARGETS, targets)
+	assert.ErrorIs(t, err, &ErrUnsignedMetadata{})
+	assert.ErrorContains(t, err, "got 1, want 2")
+
+	// Threshold of 1 still satisfied by the one underlying key.
+	root.Signed.Roles[TARGETS].Threshold = 1
+	err = root.VerifyDelegate(TARGETS, targets)
+	assert.NoError(t, err)
 }
 
 func TestVerifyLengthHashesTargetFiles(t *testing.T) {


### PR DESCRIPTION
## Summary
- Count verified threshold contributions by resolved public key fingerprint instead of key ID.
- Prevent duplicate key records for the same public key from satisfying multi-key thresholds.
- Add regression coverage for ECDSA, Ed25519, and RSA duplicate-public-key cases.

## Testing
- go test ./metadata -run 'TestVerifyDelegate(Duplicate|Threshold|$)' -count=1 -v