### PR TITLE
Replace copyMapValues with maps.Copy from stdlib

### DIFF
--- a/metadata/marshal.go
+++ b/metadata/marshal.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 )
 
 // The following marshal/unmarshal methods override the default behavior for for each TUF type
@@ -30,7 +31,7 @@ import (
 func (signed RootType) MarshalJSON() ([]byte, error) {
 	dict := map[string]any{}
 	if len(signed.UnrecognizedFields) != 0 {
-		copyMapValues(signed.UnrecognizedFields, dict)
+		maps.Copy(dict, signed.UnrecognizedFields)
 	}
 	dict["_type"] = signed.Type
 	dict["spec_version"] = signed.SpecVersion
@@ -68,7 +69,7 @@ func (signed *RootType) UnmarshalJSON(data []byte) error {
 func (signed SnapshotType) MarshalJSON() ([]byte, error) {
 	dict := map[string]any{}
 	if len(signed.UnrecognizedFields) != 0 {
-		copyMapValues(signed.UnrecognizedFields, dict)
+		maps.Copy(dict, signed.UnrecognizedFields)
 	}
 	dict["_type"] = signed.Type
 	dict["spec_version"] = signed.SpecVersion
@@ -102,7 +103,7 @@ func (signed *SnapshotType) UnmarshalJSON(data []byte) error {
 func (signed TimestampType) MarshalJSON() ([]byte, error) {
 	dict := map[string]any{}
 	if len(signed.UnrecognizedFields) != 0 {
-		copyMapValues(signed.UnrecognizedFields, dict)
+		maps.Copy(dict, signed.UnrecognizedFields)
 	}
 	dict["_type"] = signed.Type
 	dict["spec_version"] = signed.SpecVersion
@@ -136,7 +137,7 @@ func (signed *TimestampType) UnmarshalJSON(data []byte) error {
 func (signed TargetsType) MarshalJSON() ([]byte, error) {
 	dict := map[string]any{}
 	if len(signed.UnrecognizedFields) != 0 {
-		copyMapValues(signed.UnrecognizedFields, dict)
+		maps.Copy(dict, signed.UnrecognizedFields)
 	}
 	dict["_type"] = signed.Type
 	dict["spec_version"] = signed.SpecVersion
@@ -179,7 +180,7 @@ func (signed *TargetsType) UnmarshalJSON(data []byte) error {
 func (signed MetaFiles) MarshalJSON() ([]byte, error) {
 	dict := map[string]any{}
 	if len(signed.UnrecognizedFields) != 0 {
-		copyMapValues(signed.UnrecognizedFields, dict)
+		maps.Copy(dict, signed.UnrecognizedFields)
 	}
 	// length and hashes are optional
 	if signed.Length != 0 {
@@ -214,7 +215,7 @@ func (signed *MetaFiles) UnmarshalJSON(data []byte) error {
 func (signed TargetFiles) MarshalJSON() ([]byte, error) {
 	dict := map[string]any{}
 	if len(signed.UnrecognizedFields) != 0 {
-		copyMapValues(signed.UnrecognizedFields, dict)
+		maps.Copy(dict, signed.UnrecognizedFields)
 	}
 	dict["length"] = signed.Length
 	dict["hashes"] = signed.Hashes
@@ -250,7 +251,7 @@ func (signed *TargetFiles) UnmarshalJSON(data []byte) error {
 func (key Key) MarshalJSON() ([]byte, error) {
 	dict := map[string]any{}
 	if len(key.UnrecognizedFields) != 0 {
-		copyMapValues(key.UnrecognizedFields, dict)
+		maps.Copy(dict, key.UnrecognizedFields)
 	}
 	dict["keytype"] = key.Type
 	dict["scheme"] = key.Scheme
@@ -281,7 +282,7 @@ func (key *Key) UnmarshalJSON(data []byte) error {
 func (meta Metadata[T]) MarshalJSON() ([]byte, error) {
 	dict := map[string]any{}
 	if len(meta.UnrecognizedFields) != 0 {
-		copyMapValues(meta.UnrecognizedFields, dict)
+		maps.Copy(dict, meta.UnrecognizedFields)
 	}
 	dict["signed"] = meta.Signed
 	dict["signatures"] = meta.Signatures
@@ -351,7 +352,7 @@ func (meta *Metadata[T]) UnmarshalJSON(data []byte) error {
 func (s Signature) MarshalJSON() ([]byte, error) {
 	dict := map[string]any{}
 	if len(s.UnrecognizedFields) != 0 {
-		copyMapValues(s.UnrecognizedFields, dict)
+		maps.Copy(dict, s.UnrecognizedFields)
 	}
 	dict["keyid"] = s.KeyID
 	dict["sig"] = s.Signature
@@ -379,7 +380,7 @@ func (s *Signature) UnmarshalJSON(data []byte) error {
 func (kv KeyVal) MarshalJSON() ([]byte, error) {
 	dict := map[string]any{}
 	if len(kv.UnrecognizedFields) != 0 {
-		copyMapValues(kv.UnrecognizedFields, dict)
+		maps.Copy(dict, kv.UnrecognizedFields)
 	}
 	dict["public"] = kv.PublicKey
 	return json.Marshal(dict)
@@ -405,7 +406,7 @@ func (kv *KeyVal) UnmarshalJSON(data []byte) error {
 func (role Role) MarshalJSON() ([]byte, error) {
 	dict := map[string]any{}
 	if len(role.UnrecognizedFields) != 0 {
-		copyMapValues(role.UnrecognizedFields, dict)
+		maps.Copy(dict, role.UnrecognizedFields)
 	}
 	dict["keyids"] = role.KeyIDs
 	dict["threshold"] = role.Threshold
@@ -433,7 +434,7 @@ func (role *Role) UnmarshalJSON(data []byte) error {
 func (d Delegations) MarshalJSON() ([]byte, error) {
 	dict := map[string]any{}
 	if len(d.UnrecognizedFields) != 0 {
-		copyMapValues(d.UnrecognizedFields, dict)
+		maps.Copy(dict, d.UnrecognizedFields)
 	}
 	// only one is allowed
 	dict["keys"] = d.Keys
@@ -467,7 +468,7 @@ func (d *Delegations) UnmarshalJSON(data []byte) error {
 func (role DelegatedRole) MarshalJSON() ([]byte, error) {
 	dict := map[string]any{}
 	if len(role.UnrecognizedFields) != 0 {
-		copyMapValues(role.UnrecognizedFields, dict)
+		maps.Copy(dict, role.UnrecognizedFields)
 	}
 	dict["name"] = role.Name
 	dict["keyids"] = role.KeyIDs
@@ -510,7 +511,7 @@ func (role *DelegatedRole) UnmarshalJSON(data []byte) error {
 func (role SuccinctRoles) MarshalJSON() ([]byte, error) {
 	dict := map[string]any{}
 	if len(role.UnrecognizedFields) != 0 {
-		copyMapValues(role.UnrecognizedFields, dict)
+		maps.Copy(dict, role.UnrecognizedFields)
 	}
 	dict["keyids"] = role.KeyIDs
 	dict["threshold"] = role.Threshold
@@ -571,11 +572,4 @@ func (b HexBytes) MarshalJSON() ([]byte, error) {
 
 func (b HexBytes) String() string {
 	return hex.EncodeToString(b)
-}
-
-// copyMapValues copies the values of the src map to dst
-func copyMapValues(src, dst map[string]any) {
-	for k, v := range src {
-		dst[k] = v
-	}
 }

--- a/metadata/updater/updater_top_level_update_test.go
+++ b/metadata/updater/updater_top_level_update_test.go
@@ -20,6 +20,7 @@ package updater
 import (
 	"fmt"
 	"log/slog"
+	"maps"
 	"os"
 	"path/filepath"
 	"testing"
@@ -417,9 +418,7 @@ func TestIntermediateRootInclorrectlySigned(t *testing.T) {
 
 	simulator.Sim.MDRoot.Signed.Version += 1
 	rootSigners := make(map[string]*signature.Signer)
-	for k, v := range simulator.Sim.Signers[metadata.ROOT] {
-		rootSigners[k] = v
-	}
+	maps.Copy(rootSigners, simulator.Sim.Signers[metadata.ROOT])
 	for k := range simulator.Sim.Signers[metadata.ROOT] {
 		delete(simulator.Sim.Signers[metadata.ROOT], k)
 	}


### PR DESCRIPTION
maps.Copy is in stdlib since go1.21, removing the need for `func copyMapValues(src, dst map[string]any)`