### PR TITLE
Consider upating GitHub Actions dependencies to latest versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,10 +31,10 @@ jobs:
         run: git config --global core.autocrlf false
 
       - name: Checkout code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup - Go
-        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: ${{ matrix.go-version }}
           cache: true
@@ -45,4 +45,4 @@ jobs:
           GODEBUG: rsa1024min=0
 
       - name: Send coverage
-        uses: codecov/codecov-action@54bcd8715eee62d40e33596ef5e8f0f48dbbccab # v4.1.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0


### PR DESCRIPTION
Strongly consider bumping your GitHub Actions to the latest versions.

Your present actions are pinning: 

  - actions/checkout v4.1.1 (Oct 17, 2023)
  - actions/setup-go v5.0.0 (unknown, not listed in releases page) 
  - codecov/codecov-action  v4.1.0 (Feb 26, 2024)

These are all positively ancient.  All three actions have had a significant number of updates since.

At best you are missing out on new/improved functionality.  At worst you are opening yourself to supply-chain vulnerabilities.  For example if you look at recent failed runner tests:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11, actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/