### PR TITLE
Surface invalid delegation path patterns and match OS-independently

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -34,7 +34,7 @@ import (
 	"io"
 	"math"
 	"os"
-	"path/filepath"
+	"path"
 	"slices"
 	"strconv"
 	"strings"
@@ -553,7 +553,11 @@ func (role *DelegatedRole) IsDelegatedPath(targetFilepath string) (bool, error) 
 		for _, pathPattern := range role.Paths {
 			//  A delegated role path may be an explicit path or glob
 			//  pattern (Unix shell-style wildcards).
-			if isTargetInPathPattern(targetFilepath, pathPattern) {
+			matched, err := isTargetInPathPattern(targetFilepath, pathPattern)
+			if err != nil {
+				return false, err
+			}
+			if matched {
 				return true, nil
 			}
 		}
@@ -570,24 +574,32 @@ func (role *DelegatedRole) IsDelegatedPath(targetFilepath string) (bool, error) 
 }
 
 // Determine whether “targetpath“ matches the “pathpattern“.
-func isTargetInPathPattern(targetpath string, pathpattern string) bool {
+func isTargetInPathPattern(targetpath string, pathpattern string) (bool, error) {
 	// We need to make sure that targetpath and pathpattern are pointing to
 	// the same directory as fnmatch doesn't threat "/" as a special symbol.
 	targetParts := strings.Split(targetpath, "/")
 	patternParts := strings.Split(pathpattern, "/")
 	if len(targetParts) != len(patternParts) {
-		return false
+		return false, nil
 	}
 
 	// Every part in the pathpattern could include a glob pattern, that's why
-	// each of the target and pathpattern parts should match.
+	// each of the target and pathpattern parts should match. We use path.Match
+	// (not filepath.Match) so matching is independent of the host OS: TUF target
+	// paths are always "/"-separated and "\" is a glob escape, not a separator.
+	// A malformed pattern surfaces path.ErrBadPattern instead of being silently
+	// treated as a non-match.
 	for i := 0; i < len(targetParts); i++ {
-		if ok, _ := filepath.Match(patternParts[i], targetParts[i]); !ok {
-			return false
+		ok, err := path.Match(patternParts[i], targetParts[i])
+		if err != nil {
+			return false, err
+		}
+		if !ok {
+			return false, nil
 		}
 	}
 
-	return true
+	return true, nil
 }
 
 // GetRolesForTarget return the names and terminating status of all

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -34,7 +34,7 @@ import (
 	"io"
 	"math"
 	"os"
-	"path/filepath"
+	"path"
 	"slices"
 	"strconv"
 	"strings"
@@ -540,7 +540,11 @@ func (role *DelegatedRole) IsDelegatedPath(targetFilepath string) (bool, error) 
 		for _, pathPattern := range role.Paths {
 			//  A delegated role path may be an explicit path or glob
 			//  pattern (Unix shell-style wildcards).
-			if isTargetInPathPattern(targetFilepath, pathPattern) {
+			matched, err := isTargetInPathPattern(targetFilepath, pathPattern)
+			if err != nil {
+				return false, err
+			}
+			if matched {
 				return true, nil
 			}
 		}
@@ -557,24 +561,32 @@ func (role *DelegatedRole) IsDelegatedPath(targetFilepath string) (bool, error) 
 }
 
 // Determine whether “targetpath“ matches the “pathpattern“.
-func isTargetInPathPattern(targetpath string, pathpattern string) bool {
+func isTargetInPathPattern(targetpath string, pathpattern string) (bool, error) {
 	// We need to make sure that targetpath and pathpattern are pointing to
 	// the same directory as fnmatch doesn't threat "/" as a special symbol.
 	targetParts := strings.Split(targetpath, "/")
 	patternParts := strings.Split(pathpattern, "/")
 	if len(targetParts) != len(patternParts) {
-		return false
+		return false, nil
 	}
 
 	// Every part in the pathpattern could include a glob pattern, that's why
-	// each of the target and pathpattern parts should match.
+	// each of the target and pathpattern parts should match. We use path.Match
+	// (not filepath.Match) so matching is independent of the host OS: TUF target
+	// paths are always "/"-separated and "\" is a glob escape, not a separator.
+	// A malformed pattern surfaces path.ErrBadPattern instead of being silently
+	// treated as a non-match.
 	for i := range targetParts {
-		if ok, _ := filepath.Match(patternParts[i], targetParts[i]); !ok {
-			return false
+		ok, err := path.Match(patternParts[i], targetParts[i])
+		if err != nil {
+			return false, err
+		}
+		if !ok {
+			return false, nil
 		}
 	}
 
-	return true
+	return true, nil
 }
 
 // GetRolesForTarget return the names and terminating status of all

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -28,6 +28,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"os"
+	"path"
 	"path/filepath"
 	"testing"
 	"time"
@@ -286,6 +287,18 @@ func TestIsDelegatedPath(t *testing.T) {
 		assert.Equal(t, match.Expected, ok)
 		assert.Nil(t, err)
 	}
+}
+
+func TestIsDelegatedPathInvalidPattern(t *testing.T) {
+	// A malformed glob (unterminated character class) must surface an error
+	// rather than being silently treated as a non-match, so callers can tell
+	// "does not match" apart from "invalid pattern".
+	role := &DelegatedRole{
+		Paths: []string{"targets/["},
+	}
+	ok, err := role.IsDelegatedPath("targets/anything")
+	assert.False(t, ok)
+	assert.ErrorIs(t, err, path.ErrBadPattern)
 }
 
 func TestClearSignatures(t *testing.T) {


### PR DESCRIPTION
As a supply-chain-security researcher I was looking at delegation path matching and hit the fragility flagged in #747. `isTargetInPathPattern` was throwing away the error from `filepath.Match`, so a malformed pattern like an unterminated character class (`targets/[`) got silently treated as a plain non-match, and a caller couldn't tell "this pattern doesn't match" apart from "this pattern is invalid". It also used `filepath.Match`, whose separator handling depends on the host OS, even though TUF target paths are always `/`-separated.

This switches to `path.Match` (always `/`-separated, `\` as a glob escape) and propagates the error up through `IsDelegatedPath`, which already returns `(bool, error)`. I kept the change scoped to `metadata.go`; the sibling `multirepo.go` code already captures and returns that error.

I verified it by adding a regression test: on the current code the malformed-pattern case returns `err == nil`, and after the fix it returns `path.ErrBadPattern`, while the existing spec-derived path cases still pass (`go test ./metadata -run TestIsDelegatedPath -count=1`). Thanks for taking a look.