### PR TITLE
chore(deps): upgrade github.com/cenkalti/backoff to v7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/theupdateframework/go-tuf/v2
 go 1.25.0
 
 require (
-	github.com/cenkalti/backoff/v5 v5.0.3
+	github.com/cenkalti/backoff/v7 v7.0.0
 	github.com/go-logr/stdr v1.2.2
 	github.com/secure-systems-lab/go-securesystemslib v0.11.0
 	github.com/sigstore/sigstore v1.10.9

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/theupdateframework/go-tuf/v2
 go 1.25.0
 
 require (
-	github.com/cenkalti/backoff/v5 v5.0.3
+	github.com/cenkalti/backoff/v7 v7.0.0
 	github.com/go-logr/stdr v1.2.2
 	github.com/secure-systems-lab/go-securesystemslib v0.11.0
 	github.com/sigstore/sigstore v1.10.8

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
-github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
+github.com/cenkalti/backoff/v7 v7.0.0 h1:ZP+QAaaOnVUHo+ufFpZ835hbT3x2fy+h2lecVEosZ6A=
+github.com/cenkalti/backoff/v7 v7.0.0/go.mod h1:qcKBGwsu4hpxHtQ8tWYsQ+ifzx2+sS+Xx/3jfe30lI8=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
-github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
+github.com/cenkalti/backoff/v7 v7.0.0 h1:ZP+QAaaOnVUHo+ufFpZ835hbT3x2fy+h2lecVEosZ6A=
+github.com/cenkalti/backoff/v7 v7.0.0/go.mod h1:qcKBGwsu4hpxHtQ8tWYsQ+ifzx2+sS+Xx/3jfe30lI8=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/metadata/config/config.go
+++ b/metadata/config/config.go
@@ -24,7 +24,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/cenkalti/backoff/v5"
+	"github.com/cenkalti/backoff/v7"
 	"github.com/theupdateframework/go-tuf/v2/metadata/fetcher"
 )
 

--- a/metadata/config/config.go
+++ b/metadata/config/config.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/cenkalti/backoff/v7"
 	"github.com/theupdateframework/go-tuf/v2/metadata/fetcher"
 )
 
@@ -136,7 +135,7 @@ func (cfg *UpdaterConfig) SetDefaultFetcherRetry(retryInterval time.Duration, re
 	return nil
 }
 
-func (cfg *UpdaterConfig) SetRetryOptions(retryOptions ...backoff.RetryOption) error {
+func (cfg *UpdaterConfig) SetRetryOptions(retryOptions ...fetcher.RetryOption) error {
 	// Check if the configured fetcher is the default fetcher
 	// since we are only configuring retry options for the default fetcher
 	df, ok := cfg.Fetcher.(*fetcher.DefaultFetcher)

--- a/metadata/fetcher/fetcher.go
+++ b/metadata/fetcher/fetcher.go
@@ -45,13 +45,16 @@ type Fetcher interface {
 	DownloadFile(urlPath string, maxLength int64, _ time.Duration) ([]byte, error)
 }
 
+// RetryOption is an alias for backoff.RetryOption to avoid exposing the underlying dependency in exported signatures.
+type RetryOption = backoff.RetryOption
+
 // DefaultFetcher implements Fetcher
 type DefaultFetcher struct {
 	//  httpClient configuration
 	httpUserAgent string
 	client        httpClient
 	// retry logic configuration
-	retryOptions []backoff.RetryOption
+	retryOptions []RetryOption
 }
 
 func (d *DefaultFetcher) SetHTTPUserAgent(httpUserAgent string) {
@@ -126,7 +129,7 @@ func NewDefaultFetcher() *DefaultFetcher {
 	return &DefaultFetcher{
 		client: http.DefaultClient,
 		// default to attempting the HTTP request once
-		retryOptions: []backoff.RetryOption{backoff.WithMaxTries(1)},
+		retryOptions: []RetryOption{backoff.WithMaxTries(1)},
 	}
 }
 
@@ -167,6 +170,6 @@ func (f *DefaultFetcher) SetRetry(retryInterval time.Duration, retryCount uint) 
 	f.SetRetryOptions(constantBackOff, maxTryCount)
 }
 
-func (f *DefaultFetcher) SetRetryOptions(retryOptions ...backoff.RetryOption) {
+func (f *DefaultFetcher) SetRetryOptions(retryOptions ...RetryOption) {
 	f.retryOptions = retryOptions
 }

--- a/metadata/fetcher/fetcher.go
+++ b/metadata/fetcher/fetcher.go
@@ -25,7 +25,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/cenkalti/backoff/v5"
+	"github.com/cenkalti/backoff/v7"
 	"github.com/theupdateframework/go-tuf/v2/metadata"
 )
 

--- a/metadata/fetcher/fetcher_test.go
+++ b/metadata/fetcher/fetcher_test.go
@@ -152,7 +152,7 @@ func TestDownloadFile_Retry(t *testing.T) {
 			client := tt.httpClient
 			fetcher := &DefaultFetcher{
 				client: client,
-				retryOptions: []backoff.RetryOption{
+				retryOptions: []RetryOption{
 					backoff.WithMaxTries(3),
 				},
 			}

--- a/metadata/fetcher/fetcher_test.go
+++ b/metadata/fetcher/fetcher_test.go
@@ -25,7 +25,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/cenkalti/backoff/v5"
+	"github.com/cenkalti/backoff/v7"
 	"github.com/stretchr/testify/assert"
 	"github.com/theupdateframework/go-tuf/v2/metadata"
 )


### PR DESCRIPTION
Upgrade `github.com/cenkalti/backoff` from `v5` to `v7`.

Defined a type alias `fetcher.RetryOption` in the `fetcher` package and updated exported function signatures in fetcher and config packages to use this type alias instead of exposing `backoff.RetryOption` directly.