### PR TITLE
Validate the multi-repo map file before initializing any client

### DIFF
--- a/metadata/multirepo/multirepo.go
+++ b/metadata/multirepo/multirepo.go
@@ -122,10 +122,8 @@ func NewConfig(repoMap []byte, roots map[string][]byte) (*MultiRepoConfig, error
 
 // New returns a multi-repository TUF client. All repositories described in the provided map file are initialized too
 func New(config *MultiRepoConfig) (*MultiRepoClient, error) {
-	// create a multi repo client instance
-	client := &MultiRepoClient{
-		Config:     config,
-		TUFClients: map[string]*updater.Updater{},
+	if config == nil {
+		return nil, fmt.Errorf("no multi-repository config provided")
 	}
 
 	// validate the map file before initializing anything, so that a malformed map
@@ -133,6 +131,12 @@ func New(config *MultiRepoConfig) (*MultiRepoClient, error) {
 	// initialization failure or a panic during target lookup
 	if err := validateRepoMap(config.RepoMap); err != nil {
 		return nil, err
+	}
+
+	// create a multi repo client instance
+	client := &MultiRepoClient{
+		Config:     config,
+		TUFClients: map[string]*updater.Updater{},
 	}
 
 	// create TUF clients for each repository listed in the map file

--- a/metadata/multirepo/multirepo.go
+++ b/metadata/multirepo/multirepo.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -34,6 +35,14 @@ import (
 // ErrInvalidRepoName is returned when a repository name contains path traversal
 // components or is otherwise invalid for use as a directory name.
 var ErrInvalidRepoName = errors.New("invalid repository name")
+
+// ErrMissingRepoURL is returned when a repository listed in the map file has no
+// usable URL, i.e. an empty URL list or an empty first URL.
+var ErrMissingRepoURL = errors.New("repository has no URL configured")
+
+// ErrUnknownMappingRepo is returned when a mapping in the map file references a
+// repository that is not declared in the top-level repositories object.
+var ErrUnknownMappingRepo = errors.New("mapping references an unknown repository")
 
 // validRepoNamePattern defines the allowed characters for repository names.
 // Names must start with an alphanumeric character and may contain alphanumeric
@@ -119,11 +128,11 @@ func New(config *MultiRepoConfig) (*MultiRepoClient, error) {
 		TUFClients: map[string]*updater.Updater{},
 	}
 
-	// validate repository names before using them as filesystem paths
-	for repoName := range config.RepoMap.Repositories {
-		if err := validateRepoName(repoName); err != nil {
-			return nil, fmt.Errorf("repository %q: %w", repoName, err)
-		}
+	// validate the map file before initializing anything, so that a malformed map
+	// file is reported as such instead of surfacing later as an obscure
+	// initialization failure or a panic during target lookup
+	if err := validateRepoMap(config.RepoMap); err != nil {
+		return nil, err
 	}
 
 	// create TUF clients for each repository listed in the map file
@@ -138,13 +147,9 @@ func (client *MultiRepoClient) initTUFClients() error {
 	log := metadata.GetLogger()
 
 	// loop through each repository listed in the map file and initialize it
+	// note: the map file has already been validated by validateRepoMap, so each
+	// repository is guaranteed to have a usable URL at index 0
 	for repoName, repoURL := range client.Config.RepoMap.Repositories {
-		
-		// Make sure we have at least one repo URL
-		if len(repoURL) == 0 || repoURL[0] == "" {
-			return fmt.Errorf("repository %q has no URL configured", repoName)
-		}
-		
 		log.Info("Initializing", "name", repoName, "url", repoURL[0])
 
 		// get the trusted root file from the location specified in the map file relevant to its path
@@ -390,6 +395,50 @@ func (cfg *MultiRepoConfig) EnsurePathsExist() error {
 			return err
 		}
 	}
+	return nil
+}
+
+// validateRepoMap checks that a map file is internally consistent before any
+// repository is initialized. It enforces that every repository name is safe to
+// use as a filesystem path, that every repository has a usable URL, and that
+// every repository referenced by a mapping is actually declared.
+//
+// Validating up front keeps New atomic: it either returns a fully initialized
+// client or fails without having created cache directories for a subset of the
+// repositories. It also makes the reported error deterministic, which map
+// iteration order alone would not guarantee.
+func validateRepoMap(repoMap *MultiRepoMapType) error {
+	if repoMap == nil {
+		return fmt.Errorf("no repository map provided")
+	}
+
+	// sort the repository names so that a map file with more than one problem
+	// always reports the same error rather than a random one
+	for _, repoName := range slices.Sorted(maps.Keys(repoMap.Repositories)) {
+		if err := validateRepoName(repoName); err != nil {
+			return fmt.Errorf("repository %q: %w", repoName, err)
+		}
+
+		// only the first URL is used, as the client supports a single mirror per
+		// repository for the time being
+		if repoURL := repoMap.Repositories[repoName]; len(repoURL) == 0 || repoURL[0] == "" {
+			return fmt.Errorf("repository %q: %w", repoName, ErrMissingRepoURL)
+		}
+	}
+
+	// every repository named in a mapping must have a corresponding TUF client,
+	// otherwise GetTargetInfo would dereference a nil client during target lookup
+	for i, eachMap := range repoMap.Mapping {
+		if eachMap == nil {
+			return fmt.Errorf("mapping at index %d is null", i)
+		}
+		for _, repoName := range eachMap.Repositories {
+			if _, ok := repoMap.Repositories[repoName]; !ok {
+				return fmt.Errorf("mapping at index %d: %w - %s", i, ErrUnknownMappingRepo, repoName)
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/metadata/multirepo/multirepo_test.go
+++ b/metadata/multirepo/multirepo_test.go
@@ -123,3 +123,108 @@ func TestNewRejectsInvalidRepoNames(t *testing.T) {
 		})
 	}
 }
+
+func TestNewRejectsRepositoriesWithoutURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		repoURLs string
+	}{
+		{"empty URL list", `[]`},
+		{"null URL list", `null`},
+		{"empty URL string", `[""]`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mapJSON := []byte(`{
+				"repositories": {
+					"my-repo": ` + tt.repoURLs + `
+				},
+				"mapping": []
+			}`)
+
+			rootBytes := []byte(`{"signatures":[],"signed":{}}`)
+
+			cfg, err := NewConfig(mapJSON, map[string][]byte{"my-repo": rootBytes})
+			if err != nil {
+				t.Fatalf("NewConfig() unexpected error: %v", err)
+			}
+
+			_, err = New(cfg)
+			if err == nil {
+				t.Fatalf("New() should reject repository with URLs %s", tt.repoURLs)
+			}
+
+			if !errors.Is(err, ErrMissingRepoURL) {
+				t.Errorf("New() error should wrap ErrMissingRepoURL, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestNewRejectsMappingWithUnknownRepository(t *testing.T) {
+	// A mapping that references a repository absent from the top-level
+	// "repositories" object leaves no TUF client for that name, which makes
+	// GetTargetInfo dereference a nil *updater.Updater.
+	mapJSON := []byte(`{
+		"repositories": {
+			"real-repo": ["https://example.com/repo"]
+		},
+		"mapping": [
+			{
+				"paths": ["*"],
+				"repositories": ["typo-repo"],
+				"threshold": 1,
+				"terminating": true
+			}
+		]
+	}`)
+
+	rootBytes := []byte(`{"signatures":[],"signed":{}}`)
+
+	cfg, err := NewConfig(mapJSON, map[string][]byte{"real-repo": rootBytes})
+	if err != nil {
+		t.Fatalf("NewConfig() unexpected error: %v", err)
+	}
+
+	_, err = New(cfg)
+	if err == nil {
+		t.Fatal("New() should reject a mapping referencing an unknown repository")
+	}
+
+	if !errors.Is(err, ErrUnknownMappingRepo) {
+		t.Errorf("New() error should wrap ErrUnknownMappingRepo, got: %v", err)
+	}
+}
+
+func TestNewRejectsNullMapping(t *testing.T) {
+	// "mapping": [null] unmarshals into a []*Mapping holding a nil element,
+	// which GetTargetInfo would dereference while walking the mappings.
+	mapJSON := []byte(`{
+		"repositories": {
+			"real-repo": ["https://example.com/repo"]
+		},
+		"mapping": [null]
+	}`)
+
+	rootBytes := []byte(`{"signatures":[],"signed":{}}`)
+
+	cfg, err := NewConfig(mapJSON, map[string][]byte{"real-repo": rootBytes})
+	if err != nil {
+		t.Fatalf("NewConfig() unexpected error: %v", err)
+	}
+
+	_, err = New(cfg)
+	if err == nil {
+		t.Fatal("New() should reject a null mapping entry")
+	}
+}
+
+func TestNewRejectsConfigWithoutRepoMap(t *testing.T) {
+	// MultiRepoConfig has exported fields, so callers can build one directly
+	// without going through NewConfig and leave RepoMap unset.
+	_, err := New(&MultiRepoConfig{})
+	if err == nil {
+		t.Fatal("New() should reject a config with no repository map")
+	}
+}

--- a/metadata/multirepo/multirepo_test.go
+++ b/metadata/multirepo/multirepo_test.go
@@ -228,3 +228,12 @@ func TestNewRejectsConfigWithoutRepoMap(t *testing.T) {
 		t.Fatal("New() should reject a config with no repository map")
 	}
 }
+
+func TestNewRejectsNilConfig(t *testing.T) {
+	// NewConfig returns a nil config alongside its error, so a caller that
+	// ignores the error passes nil straight into New.
+	_, err := New(nil)
+	if err == nil {
+		t.Fatal("New() should reject a nil config")
+	}
+}


### PR DESCRIPTION
Follow-up to #750, addressing the review findings on that PR.

#750 correctly fixed the out-of-bounds access on `repoURL[0]` when a repository is declared with no URL. This follow-up relocates and extends that check.

## What changes

**Validation moves into a single `validateRepoMap` helper that runs before `initTUFClients`.**

`New()` already had a pre-flight loop calling `validateRepoName`; #750 put the URL check in a second place, inside the initialization loop. Consolidating them means:

- **`New` becomes atomic.** Map iteration order is randomized, so with the check inside `initTUFClients` an arbitrary number of repositories get `EnsurePathsExist()` and `updater.New()` run before the error surfaces — leaving cache directories on disk for a call that returns `nil, err` and gives the caller no handle to clean up.
- **Errors become deterministic.** Repository names are now checked in sorted order, so a map file with more than one defect reports the same error on every run.

This ordering problem is not hypothetical. Before the move, a map file whose *mapping* was malformed failed with:

```
mkdir : no such file or directory
```

because initialization began before validation finished, masking the real defect.

## Bugs fixed beyond #750

**A mapping referencing an undeclared repository panicked.** `Mapping.repositories` was never cross-checked against the top-level `repositories` object. An unknown name leaves no entry in `TUFClients`, and `GetTargetInfo` indexes it without an `ok` check, unlike `DownloadTarget` which does guard this. Confirmed against the pre-fix code:

```
PANIC CONFIRMED: runtime error: invalid memory address or nil pointer dereference
```

It needs both a matching path pattern *and* a typo'd repository name in the same mapping to trigger, which is likely why it went unnoticed.

**`"mapping": [null]` panicked.** It unmarshals into a `[]*Mapping` holding a nil element, dereferenced while walking mappings.

**A `MultiRepoConfig` with no `RepoMap` panicked.** The struct has exported fields, so callers can build one directly without going through `NewConfig`.

## Other

- Empty-URL rejection now wraps an exported `ErrMissingRepoURL` sentinel, matching the existing `ErrInvalidRepoName` convention so callers can use `errors.Is`. Unknown mapping repositories get `ErrUnknownMappingRepo`.
- Fixes the trailing-tab whitespace on the two blank lines #750 added (the repo's `.golangci.yml` enables no formatters, so CI does not currently catch `gofmt` drift).

## Compatibility

A map file with a mapping pointing at an undeclared repository is now rejected by `New()` rather than accepted and panicking later on a matching target lookup. That is a behaviour change, but it converts a latent runtime panic into an upfront configuration error. The shipped `examples/multirepo/repository/targets/map.json` was verified to pass validation unchanged.

## Tests

#750 shipped without tests; this adds regression coverage for every case above — empty/null/empty-string URL lists, unknown mapping repository, null mapping entry, and missing repository map. Each was written first and watched fail before the fix.

```
$ go test ./...        # all packages ok
$ go vet ./...         # clean
$ gofmt -l ./metadata/ # clean
$ golangci-lint run ./metadata/multirepo/...
0 issues.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)