### PR TITLE
ci: group Dependabot GitHub Actions updates into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,8 @@ updates:
       prefix: "chore"
       include: "scope"
     open-pull-requests-limit: 10
+    groups:
+      # Bundle all GitHub Actions updates into a single pull request
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Configures Dependabot to bundle all GitHub Actions version bumps into a **single** pull request per run, instead of opening one PR per action.

This is done by adding a [`groups`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups) block with a `"*"` pattern to the `github-actions` ecosystem, which matches every action.

## Why

Dependabot currently opens a separate PR for each action update (see the recent `actions/setup-go`, `actions/checkout`, `golang/govulncheck-action`, `golangci/golangci-lint-action` bumps). Grouping them cuts down PR/CI noise and lets all action bumps be reviewed and merged together.

Note: this only affects the `github-actions` ecosystem; `gomod` updates are left ungrouped and continue to open individual PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)