### PR TITLE
ci: disable golangci-lint config schema verification

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -49,3 +49,6 @@ jobs:
           # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
           version: v2.11.4
           args: --timeout 5m --verbose
+          # Skip config schema verification: it fetches the JSON schema from
+          # golangci-lint.run at runtime and flakes on network timeouts.
+          verify: false


### PR DESCRIPTION
## Summary

The `linting / golangci-lint` job fails intermittently at the `golangci-lint config verify` step with a network timeout:

```
[.golangci.yml] validate: compile schema: failing loading
"https://golangci-lint.run/jsonschema/golangci.v2.11.jsonschema.json":
context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

## Root cause

`golangci/golangci-lint-action` was bumped from v7 to v9.3.0 (#762). Starting in v8, the action defaults to `verify: true`, which runs `golangci-lint config verify`. That step downloads the config's JSON schema from `golangci-lint.run` at runtime, so the job now depends on that site being reachable and fails on network timeouts — regardless of any actual lint findings.

## Fix

Set `verify: false` on the action so linting no longer depends on external network availability. The lint run itself is unaffected.

Trade-off: schema validation of `.golangci.yml` is skipped, but golangci-lint still rejects a genuinely invalid config when it actually runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)