### PR TITLE
ci: bump golangci-lint to v2.13.1 for Go 1.27 support

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -47,7 +47,7 @@ jobs:
           # Require: The version of golangci-lint to use.
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
           # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
-          version: v2.11.4
+          version: v2.13.1
           args: --timeout 5m --verbose
           # Skip config schema verification: it fetches the JSON schema from
           # golangci-lint.run at runtime and flakes on network timeouts.


### PR DESCRIPTION
## Summary
- Update the linting workflow to use golangci-lint v2.13.1.
- Add Go 1.27 compatibility for CI lint checks.

## Testing
- Not run (CI workflow configuration change).